### PR TITLE
Elasticsearch Helper modules are grouped in one package

### DIFF
--- a/elasticsearch_helper.info.yml
+++ b/elasticsearch_helper.info.yml
@@ -2,7 +2,7 @@ name: ElasticSearch Helper
 type: module
 description: Provide tools to integrate elasticsearch with Drupal.
 core: 8.x
+package: ElasticSearch Helper
 configure: elasticsearch_helper.elasticsearch_helper_settings_form
-
 dependencies:
   - drupal:serialization

--- a/modules/elasticsearch_helper_aws/elasticsearch_helper_aws.info.yml
+++ b/modules/elasticsearch_helper_aws/elasticsearch_helper_aws.info.yml
@@ -2,6 +2,7 @@ name: AWS Elasticsearch Service for Elasticsearch Helper
 description: Connect to the AWS hosted Elasticsearch service with Elasticsearch Helper
 type: module
 core: 8.x
+package: ElasticSearch Helper
 configure: elasticsearch_helper_aws.settings_form
 dependencies:
 - elasticsearch_helper

--- a/modules/elasticsearch_helper_views/elasticsearch_helper_views.info.yml
+++ b/modules/elasticsearch_helper_views/elasticsearch_helper_views.info.yml
@@ -2,5 +2,6 @@ name: ElasticSearch Helper Views
 type: module
 description: Provides tools to integrate elasticsearch with Drupal Views.
 core: 8.x
+package: ElasticSearch Helper
 dependencies:
   - elasticsearch_helper


### PR DESCRIPTION
This change groups all the modules in one module package `Elasticsearch Helper`.