### PR TITLE
Fixes invalid status type.

### DIFF
--- a/modules/elasticsearch_helper_content/src/Plugin/Normalizer/ElasticsearchContentNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/Normalizer/ElasticsearchContentNormalizer.php
@@ -142,7 +142,7 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
       $data['url_alias'] = $object->toUrl()->toString();
       $data['created'] = $object->hasField('created') ? $object->created->value : NULL;
       // No status field => assume 1 to simplify filtering cross entity types.
-      $data['status'] = $object->hasField('status') ? $object->status->value : 1;
+      $data['status'] = $object->hasField('status') ? boolval($object->status->value) : TRUE;
 
       // Add full plain text render of $object in search_index viewmode.
       // This view mode can be configured to contain all relevant output.

--- a/modules/elasticsearch_helper_instant/src/ElasticsearchInstantSearchService.php
+++ b/modules/elasticsearch_helper_instant/src/ElasticsearchInstantSearchService.php
@@ -155,7 +155,7 @@ class ElasticsearchInstantSearchService {
               ],
             ],
             'filter' => $this->bool('must',
-              $this->optionalTermFilter('status', 1),
+              $this->optionalTermFilter('status', TRUE),
               $this->optionalTermFilter('langcode', $langcode)
             ),
           ],


### PR DESCRIPTION
**Elasticsearch content field status expected to be boolean, but integer provided.**

**Fixes:**
Convert returned 'status' type to boolean value;

**Test:**

1. Install 'Elasticsearh instant' on vanilla drupal
2. Index content_index_node and search for results

**Expected result:** no errors or warnings about invalid data type.