### PR TITLE
Feature/invalidate cache tags

### DIFF
--- a/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
+++ b/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
@@ -539,8 +539,8 @@ class Elasticsearch extends QueryPluginBase {
   }
 
   /**
- * {@inheritdoc}
- */
+   * {@inheritdoc}
+   */
   public function getCacheContexts() {
     $contexts = [];
 

--- a/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
+++ b/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
@@ -525,12 +525,22 @@ class Elasticsearch extends QueryPluginBase {
       $tags = Cache::mergeTags($entity->getCacheTags(), $tags);
     }
 
+    foreach ($this->getEntityRelationships() as $relationship) {
+      if (isset($relationship['entity_type_key'])) {
+        $entity_type_id = $this->getNestedValue($relationship['entity_type_key'], []);
+
+        if ($entity_type = \Drupal::entityManager()->getDefinition($entity_type_id, FALSE)) {
+          $tags = Cache::mergeTags($tags, $entity_type->getListCacheTags());
+        }
+      }
+    }
+
     return $tags;
   }
 
   /**
-   * {@inheritdoc}
-   */
+ * {@inheritdoc}
+ */
   public function getCacheContexts() {
     $contexts = [];
 
@@ -539,12 +549,13 @@ class Elasticsearch extends QueryPluginBase {
       $contexts = Cache::mergeContexts($contexts, $query_builder->getCacheContexts());
     }
 
-    // Add base entity type cache context.
-    if (isset($this->options['entity_relationship']['entity_type_key'])) {
-      $entity_type_id = $this->getNestedValue($this->options['entity_relationship']['entity_type_key'], []);
+    foreach ($this->getEntityRelationships() as $relationship) {
+      if (isset($relationship['entity_type_key'])) {
+        $entity_type_id = $this->getNestedValue($relationship['entity_type_key'], []);
 
-      if ($entity_type = \Drupal::entityManager()->getDefinition($entity_type_id, FALSE)) {
-        $contexts = Cache::mergeContexts($contexts, $entity_type->getListCacheContexts());
+        if ($entity_type = \Drupal::entityManager()->getDefinition($entity_type_id, FALSE)) {
+          $contexts = Cache::mergeContexts($contexts, $entity_type->getListCacheContexts());
+        }
       }
     }
 

--- a/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
+++ b/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
@@ -529,7 +529,7 @@ class Elasticsearch extends QueryPluginBase {
       if (isset($relationship['entity_type_key'])) {
         $entity_type_id = $this->getNestedValue($relationship['entity_type_key'], []);
 
-        if ($entity_type = \Drupal::entityManager()->getDefinition($entity_type_id, FALSE)) {
+        if ($entity_type = $this->entityTypeManager->getDefinition($entity_type_id, FALSE)) {
           $tags = Cache::mergeTags($tags, $entity_type->getListCacheTags());
         }
       }
@@ -553,7 +553,7 @@ class Elasticsearch extends QueryPluginBase {
       if (isset($relationship['entity_type_key'])) {
         $entity_type_id = $this->getNestedValue($relationship['entity_type_key'], []);
 
-        if ($entity_type = \Drupal::entityManager()->getDefinition($entity_type_id, FALSE)) {
+        if ($entity_type = $this->entityTypeManager->getDefinition($entity_type_id, FALSE)) {
           $contexts = Cache::mergeContexts($contexts, $entity_type->getListCacheContexts());
         }
       }


### PR DESCRIPTION
By default only view result entities cache tags are added. This is major bug as new entities can not invalidate caches leading to unusable view. 

These changes add entity list cache tags.