### PR TITLE
Feature: Index and index-alias management

### DIFF
--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php
@@ -5,6 +5,8 @@ namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
 
 /**
+ * Example versioned index.
+ *
  * @ElasticsearchIndex(
  *   id = "versioned_example_index",
  *   label = @Translation("Example Versioned Index"),
@@ -21,7 +23,7 @@ class VersionedIndex extends ElasticsearchIndexBase {
    */
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function serialize($source, $context = []) {
     /** @var \Drupal\node\Entity\Node $source */
@@ -35,7 +37,7 @@ class VersionedIndex extends ElasticsearchIndexBase {
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function setup() {
     $version = \Drupal::service('elasticsearch_helper_index_alias.service')->getCurrentVersion();

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
+
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
+
+/**
+ * @ElasticsearchIndex(
+ *   id = "versioned_example_index",
+ *   label = @Translation("Example Versioned Index"),
+ *   indexName = "versioned_example{version}",
+ *   typeName = "node",
+ *   entityType = "node",
+ *   versioned = TRUE
+ * )
+ */
+class VersionedIndex extends ElasticsearchIndexBase {
+
+  /*
+   * This index requires elasticsearch_helper_index_alias to be enabled.
+   */
+
+  /**
+   * @inheritdoc
+   */
+  public function serialize($source, $context = []) {
+    /** @var \Drupal\node\Entity\Node $source */
+
+    $data = parent::serialize($source);
+
+    // Set version information.
+    $data['version'] = \Drupal::service('elasticsearch_helper_index_alias.service')->getCurrentVersion();
+
+    return $data;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function setup() {
+    $version = \Drupal::service('elasticsearch_helper_index_alias.service')->getCurrentVersion();
+
+    $index_name = $this->getIndexName(['version' => $version]);
+
+    if (!$this->client->indices()->exists(['index' => $index_name])) {
+      $this->client->indices()->create([
+        'index' => $index_name,
+        'body' => [
+          'number_of_shards' => 1,
+          'number_of_replicas' => 1,
+        ],
+      ]);
+
+      $this->client->indices()->putMapping([
+        'index' => $index_name,
+        'type' => 'node',
+        'body' => [
+          'properties' => [
+            'title' => [
+              'type' => 'text',
+            ],
+          ],
+        ],
+      ]);
+    }
+  }
+
+}

--- a/modules/elasticsearch_helper_index_alias/README.md
+++ b/modules/elasticsearch_helper_index_alias/README.md
@@ -1,5 +1,23 @@
 
-# Elasticsearch Helper Index management
+# Elasticsearch Helper Index Alias
 
-- Manage aliases and index versions.
+- Adds version index capabilities
+- Adds index alias functionality for pointing aliases to index version.
 - Useful for re-indexing large datasets after changes to index mappings.
+
+# How to use
+
+### Setting up Index versions
+- Create and setup versioned indexes (See. VersionedIndex.php from examples)
+
+### Incrementing Index versions
+- Go to index alias management from the Admin menu: Configuration > Search and Metadata > Elasticsearch helper > Elasticsearch helper index management
+- Go to the "Aliases management" tab
+- Increment the index version as needed after changes to index field mapping.
+- Export the new version configuration and commit.
+
+### Deploying New Index Versions and Pointing Aliases
+- Run `drush eshs` to setup new index versions during deployment
+- Re-index entities from Index management tab
+- When re-indexing is done, verify that the new index version contains documents from the "Indices status" tab
+- Finally point the aliases to the new index version by clicking "Update index aliases to the latest index version" from the "Aliases management tab"

--- a/modules/elasticsearch_helper_index_alias/README.md
+++ b/modules/elasticsearch_helper_index_alias/README.md
@@ -1,0 +1,5 @@
+
+# Elasticsearch Helper Index management
+
+- Manage aliases and index versions.
+- Useful for re-indexing large datasets after changes to index mappings.

--- a/modules/elasticsearch_helper_index_alias/config/install/elasticsearch_helper_index_alias.versionconfig.yml
+++ b/modules/elasticsearch_helper_index_alias/config/install/elasticsearch_helper_index_alias.versionconfig.yml
@@ -1,0 +1,2 @@
+elasticsearch_helper_index_alias:
+  current_version: ''

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.info.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.info.yml
@@ -1,0 +1,7 @@
+name: Elasticsearch Helper Index Alias
+type: module
+description: A module which adds index versioning and alias features
+core: 8.x
+dependencies:
+  - elasticsearch_helper
+  - elasticsearch_heler_index_management

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.info.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.info.yml
@@ -4,4 +4,4 @@ description: A module which adds index versioning and alias features
 core: 8.x
 dependencies:
   - elasticsearch_helper
-  - elasticsearch_heler_index_management
+  - elasticsearch_helper_index_management

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.links.action.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.links.action.yml
@@ -1,0 +1,11 @@
+elasticsearch_helper_index_alias.manage_alias_controller.update_aliases:
+  route_name: elasticsearch_helper_index_alias.update_alias_confirm_form
+  title: 'Update index aliases to the latest index version'
+  appears_on:
+    - elasticsearch_helper_index_alias.manage_alias_controller.aliases
+
+elasticsearch_helper_index_alias.manage_alias_controller.increment_version:
+  route_name: elasticsearch_helper_index_alias.increment_version_confirm_form
+  title: 'Increment index version'
+  appears_on:
+    - elasticsearch_helper_index_alias.manage_alias_controller.aliases

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.links.task.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.links.task.yml
@@ -1,0 +1,14 @@
+elasticsearch_helper_index_alias.controller.configure:
+  route_name: elasticsearch_helper_index_management.index_list_controller_display
+  base_route: elasticsearch_helper_index_management.index_list_controller_display
+  title: 'Reindex'
+
+elasticsearch_helper_index_alias.controller.aliases:
+  route_name: elasticsearch_helper_index_alias.manage_alias_controller.aliases
+  base_route: elasticsearch_helper_index_management.index_list_controller_display
+  title: 'Aliases'
+
+elasticsearch_helper_index_alias.controller.indices_status:
+  route_name: elasticsearch_helper_index_alias.manage_alias_controller.indices_status
+  base_route: elasticsearch_helper_index_management.index_list_controller_display
+  title: 'Indices status'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.links.task.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.links.task.yml
@@ -1,12 +1,12 @@
 elasticsearch_helper_index_alias.controller.configure:
   route_name: elasticsearch_helper_index_management.index_list_controller_display
   base_route: elasticsearch_helper_index_management.index_list_controller_display
-  title: 'Reindex'
+  title: 'Index Management'
 
 elasticsearch_helper_index_alias.controller.aliases:
   route_name: elasticsearch_helper_index_alias.manage_alias_controller.aliases
   base_route: elasticsearch_helper_index_management.index_list_controller_display
-  title: 'Aliases'
+  title: 'Aliases Management'
 
 elasticsearch_helper_index_alias.controller.indices_status:
   route_name: elasticsearch_helper_index_alias.manage_alias_controller.indices_status

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
@@ -1,5 +1,5 @@
 elasticsearch_helper_index_alias.manage_alias_controller.indices_status:
-  path: '/elasticsearch_helper/manager/indices'
+  path: '/elasticsearch_helper/index_alias/indices'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::indicesStatus'
     _title: 'All indices status'
@@ -7,7 +7,7 @@ elasticsearch_helper_index_alias.manage_alias_controller.indices_status:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.manage_alias_controller.aliases:
-  path: '/elasticsearch_helper/manager/aliases'
+  path: '/elasticsearch_helper/index_alias/aliases'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::aliases'
     _title: 'Aliases status'
@@ -15,7 +15,7 @@ elasticsearch_helper_index_alias.manage_alias_controller.aliases:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.delete_index_confirm_form:
-  path: '/elasticsearch_helper_index_alias/delete/{index}/index'
+  path: '/elasticsearch_helper/index_alias/delete/{index}/index'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\DeleteIndexConfirmForm'
     _title: 'Confirm Index Deletion'
@@ -23,7 +23,7 @@ elasticsearch_helper_index_alias.delete_index_confirm_form:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.update_alias_confirm_form:
-  path: '/elasticsearch_helper_index_alias/update_all'
+  path: '/elasticsearch_helper/index_alias/update_all'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\UpdateAliasConfirmForm'
     _title: 'Confirm Index Alias Update'
@@ -31,7 +31,7 @@ elasticsearch_helper_index_alias.update_alias_confirm_form:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.increment_version_confirm_form:
-  path: '/elasticsearch_helper_index_alias/increment_version'
+  path: '/elasticsearch_helper/index_alias/increment_version'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\IncrementVersionConfirmForm'
     _title: 'Confirm Version Increment'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
@@ -5,10 +5,19 @@ elasticsearch_helper_index_alias.manage_alias_controller.indices_status:
     _title: 'All indices status'
   requirements:
     _permission: 'configured elasticsearch helper'
+
 elasticsearch_helper_index_alias.manage_alias_controller.aliases:
   path: '/elasticsearch_helper/manager/aliases'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::aliases'
     _title: 'Aliases status'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_alias.delete_index_confirm_form:
+  path: '/elasticsearch_helper_index_alias/delete/{index}/index'
+  defaults:
+    _form: '\Drupal\elasticsearch_helper_index_alias\Form\DeleteIndexConfirmForm'
+    _title: 'Confirm Index Deletion'
   requirements:
     _permission: 'configured elasticsearch helper'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
@@ -1,5 +1,5 @@
 elasticsearch_helper_index_alias.manage_alias_controller.indices_status:
-  path: '/elasticsearch_helper/index_alias/indices'
+  path: '/admin/config/search/elasticsearch_helper/index_alias/indices'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::indicesStatus'
     _title: 'All indices status'
@@ -7,7 +7,7 @@ elasticsearch_helper_index_alias.manage_alias_controller.indices_status:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.manage_alias_controller.aliases:
-  path: '/elasticsearch_helper/index_alias/aliases'
+  path: '/admin/config/search/elasticsearch_helper/index_alias/aliases'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::aliases'
     _title: 'Aliases status'
@@ -15,7 +15,7 @@ elasticsearch_helper_index_alias.manage_alias_controller.aliases:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.delete_index_confirm_form:
-  path: '/elasticsearch_helper/index_alias/delete/{index}/index'
+  path: '/admin/config/search/elasticsearch_helper/index_alias/delete/{index}/index'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\DeleteIndexConfirmForm'
     _title: 'Confirm Index Deletion'
@@ -23,7 +23,7 @@ elasticsearch_helper_index_alias.delete_index_confirm_form:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.update_alias_confirm_form:
-  path: '/elasticsearch_helper/index_alias/update_all'
+  path: '/admin/config/search/elasticsearch_helper/index_alias/update_all'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\UpdateAliasConfirmForm'
     _title: 'Confirm Index Alias Update'
@@ -31,7 +31,7 @@ elasticsearch_helper_index_alias.update_alias_confirm_form:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_alias.increment_version_confirm_form:
-  path: '/elasticsearch_helper/index_alias/increment_version'
+  path: '/admin/config/search/elasticsearch_helper/index_alias/increment_version'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\IncrementVersionConfirmForm'
     _title: 'Confirm Version Increment'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
@@ -21,3 +21,11 @@ elasticsearch_helper_index_alias.delete_index_confirm_form:
     _title: 'Confirm Index Deletion'
   requirements:
     _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_alias.update_alias_confirm_form:
+  path: '/elasticsearch_helper_index_alias/update_all'
+  defaults:
+    _form: '\Drupal\elasticsearch_helper_index_alias\Form\UpdateAliasConfirmForm'
+    _title: 'Confirm Index Deletion'
+  requirements:
+    _permission: 'configured elasticsearch helper'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
@@ -1,0 +1,14 @@
+elasticsearch_helper_index_alias.manage_alias_controller.indices_status:
+  path: '/elasticsearch_helper/manager/indices'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::indicesStatus'
+    _title: 'All indices status'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+elasticsearch_helper_index_alias.manage_alias_controller.aliases:
+  path: '/elasticsearch_helper/manager/aliases'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_alias\Controller\ManageAliasController::aliases'
+    _title: 'Aliases status'
+  requirements:
+    _permission: 'configured elasticsearch helper'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.routing.yml
@@ -26,6 +26,14 @@ elasticsearch_helper_index_alias.update_alias_confirm_form:
   path: '/elasticsearch_helper_index_alias/update_all'
   defaults:
     _form: '\Drupal\elasticsearch_helper_index_alias\Form\UpdateAliasConfirmForm'
-    _title: 'Confirm Index Deletion'
+    _title: 'Confirm Index Alias Update'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_alias.increment_version_confirm_form:
+  path: '/elasticsearch_helper_index_alias/increment_version'
+  defaults:
+    _form: '\Drupal\elasticsearch_helper_index_alias\Form\IncrementVersionConfirmForm'
+    _title: 'Confirm Version Increment'
   requirements:
     _permission: 'configured elasticsearch helper'

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.services.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.services.yml
@@ -1,0 +1,7 @@
+services:
+  logger.channel.elasticsearch_helper_index_alias:
+    parent: logger.channel_base
+    arguments: ['elasticsearch_helper_index_alias']
+  elasticsearch_helper_index_alias.service:
+    class: Drupal\elasticsearch_helper_index_alias\AliasService
+    arguments: ['@elasticsearch_helper.elasticsearch_client', '@config.manager']

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.services.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.services.yml
@@ -4,4 +4,4 @@ services:
     arguments: ['elasticsearch_helper_index_alias']
   elasticsearch_helper_index_alias.service:
     class: Drupal\elasticsearch_helper_index_alias\AliasService
-    arguments: ['@elasticsearch_helper.elasticsearch_client', '@config.manager']
+    arguments: ['@plugin.manager.elasticsearch_index.processor', '@language_manager', '@elasticsearch_helper.elasticsearch_client', '@config.manager']

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.services.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.services.yml
@@ -4,4 +4,4 @@ services:
     arguments: ['elasticsearch_helper_index_alias']
   elasticsearch_helper_index_alias.service:
     class: Drupal\elasticsearch_helper_index_alias\AliasService
-    arguments: ['@plugin.manager.elasticsearch_index.processor', '@language_manager', '@elasticsearch_helper.elasticsearch_client', '@config.manager']
+    arguments: ['@plugin.manager.elasticsearch_index.processor', '@language_manager', '@elasticsearch_helper.elasticsearch_client', '@config.manager', '@logger.channel.elasticsearch_helper_index_alias']

--- a/modules/elasticsearch_helper_index_alias/src/AliasService.php
+++ b/modules/elasticsearch_helper_index_alias/src/AliasService.php
@@ -111,7 +111,7 @@ class AliasService implements AliasServiceInterface {
 
     $version = (int) $config->get(self::CONFIG_KEY);
 
-    $config->set(self::CONFIG_KEY, $version + 1);
+    $config->set(self::CONFIG_KEY, $version + 1)->save();
   }
 
   /**

--- a/modules/elasticsearch_helper_index_alias/src/AliasService.php
+++ b/modules/elasticsearch_helper_index_alias/src/AliasService.php
@@ -99,7 +99,7 @@ class AliasService implements AliasServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public function getVersionedIndexDefinitions() {
+  public function getVersionedIndexDefinitions(): array {
     $definitions = $this->pluginManagerElasticsearchIndexProcessor->getDefinitions();
 
     // Remove non-versioned indices from definitions.
@@ -119,7 +119,7 @@ class AliasService implements AliasServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public function getVersionedIndexes() {
+  public function getVersionedIndexes(): array {
     $items = [];
 
     $indexes = $this->getVersionedIndexDefinitions();
@@ -142,7 +142,7 @@ class AliasService implements AliasServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public function updateIndexAlias(Client $client = NULL, $index_name, $version) {
+  public function updateIndexAlias(Client $client = NULL, $index_name, $version): bool {
     try {
       // Verify that destination exists before deleting current alias.
       if (!$client->indices()->exists(['index' => $index_name . $version])) {

--- a/modules/elasticsearch_helper_index_alias/src/AliasService.php
+++ b/modules/elasticsearch_helper_index_alias/src/AliasService.php
@@ -6,6 +6,7 @@ use Elasticsearch\Client;
 use Drupal\Core\Config\ConfigManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class AliasService.
@@ -55,13 +56,21 @@ class AliasService implements AliasServiceInterface {
   protected $configManager;
 
   /**
+   * Psr\Log\LoggerInterface definition.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
    * Constructs a new AliasService object.
    */
-  public function __construct(ElasticsearchIndexManager $plugin_manager_elasticsearch_index_processor, LanguageManagerInterface $language_manager, Client $elasticsearch_helper_elasticsearch_client, ConfigManagerInterface $config_manager) {
+  public function __construct(ElasticsearchIndexManager $plugin_manager_elasticsearch_index_processor, LanguageManagerInterface $language_manager, Client $elasticsearch_helper_elasticsearch_client, ConfigManagerInterface $config_manager, LoggerInterface $logger) {
     $this->pluginManagerElasticsearchIndexProcessor = $plugin_manager_elasticsearch_index_processor;
     $this->languageManager = $language_manager;
     $this->client = $elasticsearch_helper_elasticsearch_client;
     $this->configManager = $config_manager;
+    $this->logger = $logger;
   }
 
   /**
@@ -198,7 +207,7 @@ class AliasService implements AliasServiceInterface {
       return TRUE;
     }
     catch (\Exception $e) {
-      \Drupal::logger('elasticsearch_helper_index_alias.versionconfig')->debug($e->getMessage());
+      $this->logger->debug($e->getMessage());
     }
 
     return FALSE;

--- a/modules/elasticsearch_helper_index_alias/src/AliasService.php
+++ b/modules/elasticsearch_helper_index_alias/src/AliasService.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_alias;
+
+use Elasticsearch\Client;
+use Drupal\Core\Config\ConfigManagerInterface;
+
+/**
+ * Class AliasService.
+ */
+class AliasService implements AliasServiceInterface {
+
+  /**
+   * Version prefix.
+   *
+   * @var string
+   */
+  protected const VERSION_PREFIX = '_version_';
+
+  /**
+   * Version config key.
+   *
+   * @var string
+   */
+  protected const CONFIG_KEY = 'current_version';
+
+  /**
+   * Elasticsearch\Client definition.
+   *
+   * @var \Elasticsearch\Client
+   */
+  protected $client;
+
+  /**
+   * Drupal\Core\Config\ConfigManagerInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigManagerInterface
+   */
+  protected $configManager;
+
+  /**
+   * Constructs a new AliasService object.
+   */
+  public function __construct(Client $elasticsearch_helper_elasticsearch_client, ConfigManagerInterface $config_manager) {
+    $this->client = $elasticsearch_helper_elasticsearch_client;
+    $this->configManager = $config_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateAll() {
+    $versioned_indexes = $this->getVersionedIndexes();
+    $version = $this->getCurrentVersion();
+
+    // Process each index and update alias for each one.
+    if (!empty($version)) {
+      foreach ($versioned_indexes as $index_name) {
+        if ($this->updateIndexAlias($this->client, $index_name, $version)) {
+          \Drupal::messenger()->addMessage(t('Destination index updated for alias: @index', ['@index' => $index_name]), 'status');
+        }
+        else {
+          \Drupal::messenger()->addMessage(t('Updating alias failed for index: @index', ['@index' => $index_name]), 'error');
+        }
+
+        // @TODO, Dispatch event.
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCurrentVersion(): string {
+    // Get current version.
+    $version = $this->configManager
+      ->getConfigFactory()->get('elasticsearch_helper_index_alias.versionconfig')
+      ->get(self::CONFIG_KEY);
+
+    if (!empty($version)) {
+      return self::VERSION_PREFIX . (int) $version;
+    }
+
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function incrementVersion() {
+    $config = $this->configManager
+      ->getConfigFactory()->getEditable('elasticsearch_helper_index_alias.versionconfig');
+
+    $version = (int) $config->get(self::CONFIG_KEY);
+
+    $config->set(self::CONFIG_KEY, $version + 1);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getVersionedIndexDefinitions() {
+    $definitions = $this->pluginManagerElasticsearchIndexProcessor->getDefinitions();
+
+    // Remove non-versioned indices from definitions.
+    foreach ($definitions as $key => $definition) {
+      if (!isset($definition['versioned'])) {
+        unset($definitions[$key]);
+        continue;
+      }
+      if ($definition['versioned'] == FALSE) {
+        unset($definitions[$key]);
+      }
+    }
+
+    return $definitions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getVersionedIndexes() {
+    $items = [];
+
+    $indexes = $this->getVersionedIndexDefinitions();
+
+    foreach ($indexes as $key => $index) {
+      foreach ($this->languageManager->getLanguages() as $langcode => $language) {
+        // @TODO, unify detection of token replacements.
+        // Language code needs to be replace in case used in index.
+        $index_name = str_replace('{langcode}', $langcode, $index['indexName']);
+        // Remove the version so we could append it later in other methods.
+        $index_name = str_replace('{version}', '', $index_name);
+
+        $items[] = $index_name;
+      }
+    }
+
+    return $items;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateIndexAlias(Client $client = NULL, $index_name, $version) {
+    try {
+      // Verify that destination exists before deleting current alias.
+      if (!$client->indices()->exists(['index' => $index_name . $version])) {
+        throw new \Exception('Destination index does not exist: ' . $index_name . $version);
+      }
+
+      if ($client->indices()->existsAlias(['name' => $index_name, 'ignore_unavailable' => TRUE])) {
+        $index_point = $client->indices()->getAlias(['name' => $index_name]);
+        $index_point = key($index_point);
+
+        $client->indices()->deleteAlias(['name' => $index_name, 'index' => $index_point]);
+      }
+
+      // Delete old index first if it could conflict with the alias.
+      if ($client->indices()->exists(['index' => $index_name])) {
+        $client->indices()->delete(['index' => $index_name]);
+      }
+
+      // Create the new alias pointing to the new index version.
+      $client->indices()->updateAliases(
+        [
+          'body' => [
+            'actions' => [
+              [
+                'add' => [
+                  'index' => $index_name . $version,
+                  'alias' => $index_name,
+                ],
+              ],
+            ],
+          ],
+        ]
+      );
+
+      return TRUE;
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('elasticsearch_helper_index_alias.versionconfig')->debug($e->getMessage());
+    }
+
+    return FALSE;
+  }
+
+}

--- a/modules/elasticsearch_helper_index_alias/src/AliasService.php
+++ b/modules/elasticsearch_helper_index_alias/src/AliasService.php
@@ -4,6 +4,8 @@ namespace Drupal\elasticsearch_helper_index_alias;
 
 use Elasticsearch\Client;
 use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager;
 
 /**
  * Class AliasService.
@@ -25,6 +27,20 @@ class AliasService implements AliasServiceInterface {
   protected const CONFIG_KEY = 'current_version';
 
   /**
+   * Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager definition.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
+   */
+  protected $pluginManagerElasticsearchIndexProcessor;
+
+  /**
+   * Drupal\Core\Language\LanguageManagerInterface definition.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
    * Elasticsearch\Client definition.
    *
    * @var \Elasticsearch\Client
@@ -41,7 +57,9 @@ class AliasService implements AliasServiceInterface {
   /**
    * Constructs a new AliasService object.
    */
-  public function __construct(Client $elasticsearch_helper_elasticsearch_client, ConfigManagerInterface $config_manager) {
+  public function __construct(ElasticsearchIndexManager $plugin_manager_elasticsearch_index_processor, LanguageManagerInterface $language_manager, Client $elasticsearch_helper_elasticsearch_client, ConfigManagerInterface $config_manager) {
+    $this->pluginManagerElasticsearchIndexProcessor = $plugin_manager_elasticsearch_index_processor;
+    $this->languageManager = $language_manager;
     $this->client = $elasticsearch_helper_elasticsearch_client;
     $this->configManager = $config_manager;
   }

--- a/modules/elasticsearch_helper_index_alias/src/AliasServiceInterface.php
+++ b/modules/elasticsearch_helper_index_alias/src/AliasServiceInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_alias;
+
+use Elasticsearch\Client;
+
+/**
+ * Interface AliasServiceInterface.
+ */
+interface AliasServiceInterface {
+
+  /**
+   * Update all versioned index.
+   */
+  public function updateAll();
+
+  /**
+   * Get current version.
+   *
+   * @return string
+   *   The string version.
+   */
+  public function getCurrentVersion(): string;
+
+  /**
+   * Increments the version.
+   */
+  public function incrementVersion();
+
+  /**
+   * Get defintions of versioned indices.
+   *
+   * @return array
+   *   An array of index plugin definitions.
+   */
+  public function getVersionedIndexDefinitions() : array;
+
+  /**
+   * Get only the index names of versioned index.
+   *
+   * @return array
+   *   An array of index names.
+   */
+  public function getVersionedIndexes() : array;
+
+  /**
+   * Point the alias to the new index version name.
+   *
+   * Old indices will be deleted during first use.
+   *
+   * @param \Elasticsearch\Client $client
+   *   The elasticsearch client (Optional)
+   * @param string $index_name
+   *   The index name.
+   * @param string $version
+   *   The index version.
+   *
+   * @return bool
+   *   Returns True or False.
+   */
+  public function updateIndexAlias(Client $client, $index_name, $version) : bool;
+
+}

--- a/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
+++ b/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
@@ -7,7 +7,6 @@ use Drupal\Core\Link;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Elasticsearch\Client;
 use Drupal\Core\State\StateInterface;
-use Drupal\Core\Site\Settings;
 
 /**
  * Class ManageAliasController.
@@ -31,20 +30,11 @@ class ManageAliasController extends ControllerBase {
   protected $state;
 
   /**
-   * Current alias version.
-   *
-   * @var string
-   */
-  protected $currentVersion;
-
-  /**
    * Constructs a new ManagementController object.
    */
   public function __construct(Client $client, StateInterface $state) {
     $this->client = $client;
     $this->state = $state;
-
-    $this->currentVersion = Settings::get('elasticsearch_index_version', '');
   }
 
   /**

--- a/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
+++ b/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
@@ -3,6 +3,7 @@
 namespace Drupal\elasticsearch_helper_index_alias\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Link;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Elasticsearch\Client;
 use Drupal\Core\State\StateInterface;
@@ -62,7 +63,7 @@ class ManageAliasController extends ControllerBase {
    * @return array
    *   Renderable array
    */
-  public function indicesStatus() {
+  public function indicesStatus(): array {
     $response = $this->client->cat()->indices();
 
     $header = [
@@ -88,7 +89,12 @@ class ManageAliasController extends ControllerBase {
         $count['count'],
         $item['store.size'],
         $item['health'],
-        '',
+        Link::createFromRoute(
+          $this->t('Delete Index'),
+          'elasticsearch_helper_index_alias.delete_index_confirm_form',
+          ['index' => $item['index']],
+          ['attributes' => ['class' => 'button']]
+        ),
       ];
     }
 

--- a/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
+++ b/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_alias\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Elasticsearch\Client;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\Site\Settings;
+
+/**
+ * Class ManageAliasController.
+ *
+ * The controller displays the current state of the aliases and index versions.
+ */
+class ManageAliasController extends ControllerBase {
+
+  /**
+   * Elasticsearch\Client definition.
+   *
+   * @var \Elasticsearch\Client
+   */
+  protected $client;
+
+  /**
+   * Drupal\Core\State\StateInterface definition.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Current alias version.
+   *
+   * @var string
+   */
+  protected $currentVersion;
+
+  /**
+   * Constructs a new ManagementController object.
+   */
+  public function __construct(Client $client, StateInterface $state) {
+    $this->client = $client;
+    $this->state = $state;
+
+    $this->currentVersion = Settings::get('elasticsearch_index_version', '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('elasticsearch_helper.elasticsearch_client'),
+      $container->get('state')
+    );
+  }
+
+  /**
+   * Lists all the indices status.
+   *
+   * @return array
+   *   Renderable array
+   */
+  public function indicesStatus() {
+    $response = $this->client->cat()->indices();
+
+    $header = [
+      $this->t('Name'),
+      $this->t('Documents'),
+      $this->t('Size'),
+      $this->t('Health'),
+      $this->t('Actions'),
+    ];
+
+    // Sort by index name.
+    usort($response, function ($a, $b) {
+      return $a['index'] <=> $b['index'];
+    });
+
+    $rows = [];
+
+    foreach ($response as $item) {
+      $count = $this->client->count(['index' => $item['index']]);
+
+      $rows[] = [
+        $item['index'],
+        $count['count'],
+        $item['store.size'],
+        $item['health'],
+        '',
+      ];
+    }
+
+    return [
+      '#type' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+    ];
+  }
+
+  /**
+   * Lists the current active aliases and their destination index.
+   *
+   * @return array
+   *   Renderable array
+   */
+  public function aliases(): array {
+    $aliases = $this->client->cat()->aliases();
+
+    $rows = [];
+
+    foreach ($aliases as $alias) {
+      $rows[] = [
+        $alias['alias'],
+        $alias['index'],
+      ];
+    }
+
+    return [
+      '#type' => 'table',
+      '#header' => [$this->t('Name'), $this->t('Destination Index')],
+      '#rows' => $rows,
+    ];
+  }
+
+}

--- a/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
+++ b/modules/elasticsearch_helper_index_alias/src/Controller/ManageAliasController.php
@@ -4,9 +4,9 @@ namespace Drupal\elasticsearch_helper_index_alias\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Link;
+use Drupal\elasticsearch_helper_index_alias\AliasServiceInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Elasticsearch\Client;
-use Drupal\Core\State\StateInterface;
 
 /**
  * Class ManageAliasController.
@@ -23,18 +23,18 @@ class ManageAliasController extends ControllerBase {
   protected $client;
 
   /**
-   * Drupal\Core\State\StateInterface definition.
+   * Drupal\elasticsearch_helper_index_alias\AliasServiceInterface definition.
    *
-   * @var \Drupal\Core\State\StateInterface
+   * @var \Drupal\elasticsearch_helper_index_alias\AliasServiceInterface
    */
-  protected $state;
+  protected $aliasService;
 
   /**
    * Constructs a new ManagementController object.
    */
-  public function __construct(Client $client, StateInterface $state) {
+  public function __construct(Client $client, AliasServiceInterface $alias_service) {
     $this->client = $client;
-    $this->state = $state;
+    $this->aliasService = $alias_service;
   }
 
   /**
@@ -43,7 +43,7 @@ class ManageAliasController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('elasticsearch_helper.elasticsearch_client'),
-      $container->get('state')
+      $container->get('elasticsearch_helper_index_alias.service')
     );
   }
 
@@ -102,6 +102,7 @@ class ManageAliasController extends ControllerBase {
    *   Renderable array
    */
   public function aliases(): array {
+    $version = $this->aliasService->getCurrentVersion();
     $aliases = $this->client->cat()->aliases();
 
     $rows = [];
@@ -114,6 +115,7 @@ class ManageAliasController extends ControllerBase {
     }
 
     return [
+      '#caption' => $this->t('Current index version: @version', ['@version' => $version]),
       '#type' => 'table',
       '#header' => [$this->t('Name'), $this->t('Destination Index')],
       '#rows' => $rows,

--- a/modules/elasticsearch_helper_index_alias/src/Form/DeleteIndexConfirmForm.php
+++ b/modules/elasticsearch_helper_index_alias/src/Form/DeleteIndexConfirmForm.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_alias\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Elasticsearch\Client;
+
+/**
+ * Class DeleteIndexConfirmForm.
+ *
+ * Ask the user for confirmation before dropping index.
+ */
+class DeleteIndexConfirmForm extends ConfirmFormBase {
+
+  /**
+   * Redirect route after form actions.
+   */
+  protected const REDIRECT_ROUTE = 'elasticsearch_helper_index_alias.manage_alias_controller.indices_status';
+
+  /**
+   * Elasticsearch\Client definition.
+   *
+   * @var \Elasticsearch\Client
+   */
+  protected $elasticsearchHelperElasticsearchClient;
+
+  /**
+   * Constructs a new DeleteIndexConfirmForm object.
+   */
+  public function __construct(
+    Client $elasticsearch_helper_elasticsearch_client
+  ) {
+    $this->elasticsearchHelperElasticsearchClient = $elasticsearch_helper_elasticsearch_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $index = NULL) {
+    $this->index = $index;
+
+    $form_state->set('index', $index);
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('elasticsearch_helper.elasticsearch_client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $index_name = $form_state->get('index');
+
+    if (!empty($index_name)) {
+      /** @var \Elasticsearch\Client $client */
+      $client = \Drupal::service('elasticsearch_helper.elasticsearch_client');
+
+      $client->indices()->delete(['index' => $index_name]);
+
+      \Drupal::messenger()->addMessage(t('Index deleted: @index', ['@index' => $index_name]), 'status');
+    }
+
+    $form_state->setRedirect(self::REDIRECT_ROUTE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return "elasticsearch_helper_delete_confirm_form";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url(self::REDIRECT_ROUTE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return t('Confirm to drop index: @index?', ['@index' => $this->index]);
+  }
+
+}

--- a/modules/elasticsearch_helper_index_alias/src/Form/IncrementVersionConfirmForm.php
+++ b/modules/elasticsearch_helper_index_alias/src/Form/IncrementVersionConfirmForm.php
@@ -49,6 +49,13 @@ class IncrementVersionConfirmForm extends ConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->aliasService->incrementVersion();
 
+    $this->messenger()->addStatus(
+      $this->t(
+        'Index version is now: @version',
+        ['@version' => $this->aliasService->getCurrentVersion()]
+      )
+    );
+
     $form_state->setRedirect('elasticsearch_helper_index_alias.manage_alias_controller.aliases');
   }
 

--- a/modules/elasticsearch_helper_index_alias/src/Form/IncrementVersionConfirmForm.php
+++ b/modules/elasticsearch_helper_index_alias/src/Form/IncrementVersionConfirmForm.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_alias\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\elasticsearch_helper_index_alias\AliasService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class IncrementVersionConfirmForm.
+ *
+ * Ask the user to confirm that version number should be incremented.
+ */
+class IncrementVersionConfirmForm extends ConfirmFormBase {
+
+  /**
+   * Redirect route after form actions.
+   */
+  protected const REDIRECT_ROUTE = 'elasticsearch_helper_index_alias.manage_alias_controller.indices_status';
+
+  /**
+   * Alias service definition.
+   *
+   * @var \Drupal\elasticsearch_helper_index_alias\AliasService
+   */
+  protected $aliasService;
+
+  /**
+   * Constructs a new DeleteIndexConfirmForm object.
+   */
+  public function __construct(AliasService $alias_service) {
+    $this->aliasService = $alias_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('elasticsearch_helper_index_alias.service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->aliasService->incrementVersion();
+
+    $form_state->setRedirect('elasticsearch_helper_index_alias.manage_alias_controller.aliases');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return "elasticsearch_helper_index_alias_update_form";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('elasticsearch_helper_index_alias.manage_alias_controller.aliases');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return t('Increment the index version?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return t('Note: Run index setup drush command and export configuration after version is incremented');
+  }
+
+}

--- a/modules/elasticsearch_helper_index_alias/src/Form/UpdateAliasConfirmForm.php
+++ b/modules/elasticsearch_helper_index_alias/src/Form/UpdateAliasConfirmForm.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_alias\Form;
+
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\elasticsearch_helper_index_alias\AliasService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class UpdateAliasConfirmForm.
+ *
+ * Ask the user to confirm index alias updates.
+ */
+class UpdateAliasConfirmForm extends ConfirmFormBase {
+
+  /**
+   * Redirect route after form actions.
+   */
+  protected const REDIRECT_ROUTE = 'elasticsearch_helper_index_alias.manage_alias_controller.indices_status';
+
+  /**
+   * Alias service definition.
+   *
+   * @var \Drupal\elasticsearch_helper_index_alias\AliasService
+   */
+  protected $aliasService;
+
+  /**
+   * Constructs a new DeleteIndexConfirmForm object.
+   */
+  public function __construct(AliasService $alias_service) {
+    $this->aliasService = $alias_service;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('elasticsearch_helper_index_alias.service')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->aliasService->updateAll();
+
+    $form_state->setRedirect('elasticsearch_helper_index_alias.elasticsearch_management_controller_aliases');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() : string {
+    return "elasticsearch_helper_index_alias_update_form";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return new Url('elasticsearch_helper_index_alias.elasticsearch_management_controller_aliases');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return t('Confirm to update aliases to latest index version?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return t('Warning: This will delete any index that matches the alias and will point the alias to the new index version! Make sure that the new index version contains all the documents! Press CANCEL now if you are not sure!');
+  }
+
+}

--- a/modules/elasticsearch_helper_index_alias/src/Form/UpdateAliasConfirmForm.php
+++ b/modules/elasticsearch_helper_index_alias/src/Form/UpdateAliasConfirmForm.php
@@ -49,7 +49,7 @@ class UpdateAliasConfirmForm extends ConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->aliasService->updateAll();
 
-    $form_state->setRedirect('elasticsearch_helper_index_alias.elasticsearch_management_controller_aliases');
+    $form_state->setRedirect('elasticsearch_helper_index_alias.manage_alias_controller.aliases');
   }
 
   /**
@@ -63,7 +63,7 @@ class UpdateAliasConfirmForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getCancelUrl() {
-    return new Url('elasticsearch_helper_index_alias.elasticsearch_management_controller_aliases');
+    return new Url('elasticsearch_helper_index_alias.manage_alias_controller.aliases');
   }
 
   /**

--- a/modules/elasticsearch_helper_index_management/README.md
+++ b/modules/elasticsearch_helper_index_management/README.md
@@ -1,0 +1,5 @@
+
+# Elasticsearch Helper Index management
+
+- Manage re-indexes from the administrative UI.
+- Allow re-indexing of failed items.

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.info.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.info.yml
@@ -2,6 +2,5 @@ name: Elasticsearch Helper Index management
 type: module
 description: A module for managing indices in elasticsearch.
 core: 8.x
-hidden: true
 dependencies:
-- elasticsearch_helper
+  - elasticsearch_helper

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.info.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.info.yml
@@ -1,0 +1,7 @@
+name: Elasticsearch Helper Index management
+type: module
+description: A module for managing indices in elasticsearch.
+core: 8.x
+hidden: true
+dependencies:
+- elasticsearch_helper

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.install
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.install
@@ -16,14 +16,14 @@ function elasticsearch_helper_index_management_schema() {
       'plugin_id' => [
         'description' => 'The index plugin id',
         'type' => 'varchar',
-        'length' => 255,
+        'length' => 125,
         'not null' => TRUE,
         'default' => '',
       ],
       'entity_type' => [
         'description' => 'The entity type id',
         'type' => 'varchar',
-        'length' => 255,
+        'length' => 125,
         'not null' => TRUE,
         'default' => '',
       ],

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.install
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.install
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Implements hook_schema().
+ */
+function elasticsearch_helper_index_management_schema() {
+  $schema['es_reindex_queue'] = [
+    'description' => 'Queue table for elasticsearch re-indexing',
+    'fields' => [
+      'id' => [
+        'description' => 'The primary identifier for product',
+        'type' => 'serial',
+        'not null' => TRUE,
+        'unsigned' => TRUE,
+      ],
+      'plugin_id' => [
+        'description' => 'The index plugin id',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+      'entity_type' => [
+        'description' => 'The entity type id',
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+      'entity_id' => [
+        'description' => 'The entity id',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'error' => [
+        'description' => 'Indicate if indexing of an entity resulted in an error',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'status' => [
+        'description' => 'Indicate if entity has been indexed successfully',
+        'type' => 'int',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+    ],
+    'indexes' => [
+      'entity_error' => [
+        'error',
+      ],
+      'index_done' => [
+        'status',
+      ],
+    ],
+    'unique keys' => [
+      'plugin_keys' => [
+        'plugin_id',
+        'entity_type',
+        'entity_id',
+      ],
+    ],
+    'primary key' => [
+      'id',
+    ],
+  ];
+
+  return $schema;
+}

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.install
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.install
@@ -43,7 +43,6 @@ function elasticsearch_helper_index_management_schema() {
       'status' => [
         'description' => 'Indicate if entity has been indexed successfully',
         'type' => 'int',
-        'type' => 'int',
         'not null' => TRUE,
         'default' => 0,
       ],

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.links.action.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.links.action.yml
@@ -1,0 +1,17 @@
+elasticsearch_helper_index_management.reindex.queue:
+  route_name: elasticsearch_helper_index_management.reindex_controller_queue_all
+  title: 'Queue all for re-indexing'
+  appears_on:
+    - elasticsearch_helper_index_management.reindex_controller_status
+
+elasticsearch_helper_index_management.reindex.clear:
+  route_name: elasticsearch_helper_index_management.reindex_controller_clear
+  title: 'Remove all items from queue'
+  appears_on:
+    - elasticsearch_helper_index_management.reindex_controller_status
+
+elasticsearch_helper_index_management.reindex.process:
+  route_name: elasticsearch_helper_index_management.reindex_controller_process_all
+  title: 'Batch process all Queue items'
+  appears_on:
+    - elasticsearch_helper_index_management.reindex_controller_status

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.links.menu.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.links.menu.yml
@@ -1,0 +1,5 @@
+elasticsearch_helper_index_management:
+  title: 'Elasticsearch Helper Index Management'
+  route_name: elasticsearch_helper_index_management.index_list_controller_display
+  description: 'Manage Elasticsearch Helper Indexes'
+  parent: elasticsearch_helper.elasticsearch_helper_settings_form

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.routing.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.routing.yml
@@ -1,17 +1,16 @@
-
 elasticsearch_helper_index_management.index_list_controller_display:
   path: '/elasticsearch_helper_index_management/indices'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ListController::display'
-    _title: 'Indices'
+    _title: 'Index Management'
   requirements:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_management.reindex_controller_status:
-  path: '/elasticsearch_helper_index_management/status/{index_id}'
+  path: '/elasticsearch_helper_index_management/indices/status/{index_id}'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::status'
-    _title: 'Re-index status'
+    _title: 'Index status'
   requirements:
     _permission: 'configured elasticsearch helper'
 

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.routing.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.routing.yml
@@ -1,5 +1,5 @@
 elasticsearch_helper_index_management.index_list_controller_display:
-  path: '/elasticsearch_helper_index_management/indices'
+  path: '/admin/config/search/elasticsearch_helper/index_management/indices'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ListController::display'
     _title: 'Index Management'
@@ -7,7 +7,7 @@ elasticsearch_helper_index_management.index_list_controller_display:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_management.reindex_controller_status:
-  path: '/elasticsearch_helper_index_management/indices/status/{index_id}'
+  path: '/admin/config/search/elasticsearch_helper/index_management/indices/status/{index_id}'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::status'
     _title: 'Index status'
@@ -15,7 +15,7 @@ elasticsearch_helper_index_management.reindex_controller_status:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_management.reindex_controller_queue_all:
-  path: '/elasticsearch_helper_index_management/queue_all/{index_id}'
+  path: '/admin/config/search/elasticsearch_helper/index_management/queue_all/{index_id}'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::queueAll'
     _title: 'Queue all items for re-index'
@@ -23,7 +23,7 @@ elasticsearch_helper_index_management.reindex_controller_queue_all:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_management.reindex_controller_process_all:
-  path: '/elasticsearch_helper_index_management/process_all/{index_id}'
+  path: '/admin/config/search/elasticsearch_helper/index_management/process_all/{index_id}'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::processAll'
     _title: 'Batch process re-index queue'
@@ -31,7 +31,7 @@ elasticsearch_helper_index_management.reindex_controller_process_all:
     _permission: 'configured elasticsearch helper'
 
 elasticsearch_helper_index_management.reindex_controller_clear:
-  path: '/elasticsearch_helper_index_management/clear/{index_id}'
+  path: '/admin/config/search/elasticsearch_helper/index_management/clear/{index_id}'
   defaults:
     _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::clear'
     _title: 'Remove all items from re-index queue'

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.routing.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.routing.yml
@@ -1,0 +1,40 @@
+
+elasticsearch_helper_index_management.index_list_controller_display:
+  path: '/elasticsearch_helper_index_management/indices'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ListController::display'
+    _title: 'Indices'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_management.reindex_controller_status:
+  path: '/elasticsearch_helper_index_management/status/{index_id}'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::status'
+    _title: 'Re-index status'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_management.reindex_controller_queue_all:
+  path: '/elasticsearch_helper_index_management/queue_all/{index_id}'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::queueAll'
+    _title: 'Queue all items for re-index'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_management.reindex_controller_process_all:
+  path: '/elasticsearch_helper_index_management/process_all/{index_id}'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::processAll'
+    _title: 'Batch process re-index queue'
+  requirements:
+    _permission: 'configured elasticsearch helper'
+
+elasticsearch_helper_index_management.reindex_controller_clear:
+  path: '/elasticsearch_helper_index_management/clear/{index_id}'
+  defaults:
+    _controller: '\Drupal\elasticsearch_helper_index_management\Controller\ReindexController::clear'
+    _title: 'Remove all items from re-index queue'
+  requirements:
+    _permission: 'configured elasticsearch helper'

--- a/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.services.yml
+++ b/modules/elasticsearch_helper_index_management/elasticsearch_helper_index_management.services.yml
@@ -1,0 +1,7 @@
+services:
+  logger.channel.elasticsearch_helper_index_management:
+    parent: logger.channel_base
+    arguments: ['elasticsearch_helper_index_management']
+  elasticsearch_helper_index_management.queue_manager:
+    class: Drupal\elasticsearch_helper_index_management\ElasticsearchQueueManager
+    arguments: ['@database', '@plugin.manager.elasticsearch_index.processor', '@entity_type.manager']

--- a/modules/elasticsearch_helper_index_management/src/Controller/ListController.php
+++ b/modules/elasticsearch_helper_index_management/src/Controller/ListController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Link;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class ListController.
+ */
+class ListController extends ControllerBase {
+
+  /**
+   * Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager definition.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
+   */
+  protected $elasticsearchHelperPluginManager;
+
+  /**
+   * Constructs a new ListController object.
+   */
+  public function __construct(ElasticsearchIndexManager $elasticsearch_plugin_manager) {
+    $this->elasticsearchHelperPluginManager = $elasticsearch_plugin_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.elasticsearch_index.processor')
+    );
+  }
+
+  /**
+   * List index plugins.
+   *
+   * @return string
+   *   List markup.
+   */
+  public function display() {
+    // Define headers.
+    $header = [
+      $this->t('Name'),
+      $this->t('Index ID'),
+      $this->t('Entity Type'),
+      $this->t('Action'),
+    ];
+
+    // Build rows.
+    $rows = [];
+
+    foreach ($this->elasticsearchHelperPluginManager->getDefinitions() as $plugin) {
+      $action = Link::createFromRoute(
+        $this->t('Manage'),
+        'elasticsearch_helper_index_management.reindex_controller_status',
+        ['index_id' => $plugin['id']],
+        ['attributes' => ['class' => 'button']]
+      );
+
+      $rows[] = [
+        $plugin['label'],
+        $plugin['id'],
+        $plugin['entityType'],
+        $action,
+      ];
+    }
+
+    return [
+      '#type' => 'table',
+      '#header' => $header,
+      '#rows' => $rows,
+    ];
+  }
+
+}

--- a/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
+++ b/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
@@ -47,6 +47,9 @@ class ReindexController extends ControllerBase {
   /**
    * Display current re-index status.
    *
+   * @param string $index_id
+   *   The index plugin id.
+   *
    * @return string
    *   Status markup.
    */
@@ -80,6 +83,12 @@ class ReindexController extends ControllerBase {
 
   /**
    * Add items to re-index queue.
+   *
+   * @param string $index_id
+   *   The index plugin id.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect response.
    */
   public function queueAll($index_id) {
     $this->elasticsearchQueueManager->addAll($index_id);
@@ -89,6 +98,12 @@ class ReindexController extends ControllerBase {
 
   /**
    * Process queue items.
+   *
+   * @param string $index_id
+   *   The index plugin id.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect response.
    */
   public function processAll($index_id) {
     // Get items from processing.
@@ -117,6 +132,12 @@ class ReindexController extends ControllerBase {
 
   /**
    * Delete all items from re-index queue.
+   *
+   * @param string $index_id
+   *   The index plugin id.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect response.
    */
   public function clear($index_id) {
     $this->elasticsearchQueueManager->clear($index_id);

--- a/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
+++ b/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
@@ -6,6 +6,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager;
+use Drupal\elasticsearch_helper_index_management\ElasticsearchBatchManager;
 use Drupal\elasticsearch_helper_index_management\ElasticsearchQueueManagerInterface;
 
 /**
@@ -116,12 +117,12 @@ class ReindexController extends ControllerBase {
       'init_message' => $this->t('Starting'),
       'progress_message' => $this->t('Processed @current out of @total.'),
       'error_message' => $this->t('An error occurred during processing'),
-      'finished' => '\Drupal\elasticsearch_helper_index_management\ElasticsearchBatchManager::processFinished',
+      'finished' => ElasticsearchBatchManager::class . '::processFinished',
     ];
 
     foreach ($items as $item) {
       if (!$item->status) {
-        $batch['operations'][] = ['\Drupal\elasticsearch_helper_index_management\ElasticsearchBatchManager::processOne', [$item->id]];
+        $batch['operations'][] = [ElasticsearchBatchManager::class . '::processOne', [$item->id]];
       }
     }
 

--- a/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
+++ b/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager;
+use Drupal\elasticsearch_helper_index_management\ElasticsearchQueueManagerInterface;
+
+/**
+ * Class ReindexController.
+ */
+class ReindexController extends ControllerBase {
+  /**
+   * Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager definition.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
+   */
+  protected $elasticsearchHelperPluginManager;
+
+  /**
+   * Drupal\elasticsearch_helper_index_management\ElasticsearchQueueManager definition.
+   *
+   * @var \Drupal\elasticsearch_helper_index_management\ElasticsearchQueueManager
+   */
+  protected $elasticsearchQueueManager;
+
+  /**
+   * Constructs a new IndexListController object.
+   */
+  public function __construct(ElasticsearchIndexManager $elasticsearch_plugin_manager, ElasticsearchQueueManagerInterface $elasticsearch_queue_manager) {
+    $this->elasticsearchHelperPluginManager = $elasticsearch_plugin_manager;
+    $this->elasticsearchQueueManager = $elasticsearch_queue_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.elasticsearch_index.processor'),
+      $container->get('elasticsearch_helper_index_management.queue_manager')
+    );
+  }
+
+  /**
+   * Display current re-index status.
+   *
+   * @return string
+   *   Status markup.
+   */
+  public function status($index_id) {
+    $definition = $this->elasticsearchHelperPluginManager->getDefinition($index_id);
+
+    $status = $this->elasticsearchQueueManager->getStatus($definition['id']);
+
+    if ($status['total']) {
+      $status_text = $status['processed'] . '/' . $status['total'] . ' items processed';
+
+      if ($status['errors']) {
+        $status_text .= ' (' . $status['errors'] . ' items not indexed due to errors)';
+      }
+    }
+    else {
+      $status_text = 'There are currently no items queued for re-indexing';
+    }
+
+    $rows = [
+      ['Index', $definition['label'] . ' (' . $definition['id'] . ')'],
+      ['Entity Type', $definition['entityType']],
+      ['Status', $status_text],
+    ];
+
+    return [
+      '#type' => 'table',
+      '#rows' => $rows,
+    ];
+  }
+
+  /**
+   * Add items to re-index queue.
+   */
+  public function queueAll($index_id) {
+    $this->elasticsearchQueueManager->addAll($index_id);
+
+    return $this->redirect('elasticsearch_helper_index_management.reindex_controller_status', ['index_id' => $index_id]);
+  }
+
+  /**
+   * Process queue items.
+   */
+  public function processAll($index_id) {
+    // Get items from processing.
+    $items = $this->elasticsearchQueueManager->getItems($index_id);
+
+    // Create a batch for processing re-indexing.
+    $batch = [
+      'title' => $this->t('Re-indexing @id', ['@id' => $index_id]),
+      'operations' => [],
+      'init_message' => $this->t('Starting'),
+      'progress_message' => $this->t('Processed @current out of @total.'),
+      'error_message' => $this->t('An error occurred during processing'),
+      'finished' => '\Drupal\elasticsearch_helper_index_management\ElasticsearchBatchManager::processFinished',
+    ];
+
+    foreach ($items as $item) {
+      if (!$item->status) {
+        $batch['operations'][] = ['\Drupal\elasticsearch_helper_index_management\ElasticsearchBatchManager::processOne', [$item->id]];
+      }
+    }
+
+    batch_set($batch);
+
+    return batch_process(Url::fromRoute('elasticsearch_helper_index_management.reindex_controller_status', ['index_id' => $index_id]));
+  }
+
+  /**
+   * Delete all items from re-index queue.
+   */
+  public function clear($index_id) {
+    $this->elasticsearchQueueManager->clear($index_id);
+
+    return $this->redirect('elasticsearch_helper_index_management.reindex_controller_status', ['index_id' => $index_id]);
+  }
+
+}

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchBatchManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchBatchManager.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management;
+
+use Elasticsearch\Common\Exceptions\ElasticsearchException;
+
+/**
+ * Batch manager class.
+ */
+class ElasticsearchBatchManager {
+
+  /**
+   * Process one item from re-index queue.
+   *
+   * @param int $id
+   *   The queue item's id.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function processOne($id, &$context) {
+    /** @var \Drupal\elasticsearch_helper_index_management\ElasticsearchQueueManager $queue_manager */
+    $queue_manager = \drupal::service('elasticsearch_helper_index_management.queue_manager');
+
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = \Drupal::service('entity_type.manager');
+
+    if ($item = $queue_manager->getItem($id)) {
+      if ($entity = $entity_type_manager->getStorage($item->entity_type)->load($item->entity_id)) {
+        if (self::indexEntity($entity)) {
+          $queue_manager->setStatus($id, 1);
+          $queue_manager->setError($id, 0);
+          $context['results'][] = $id;
+        }
+        else {
+          $queue_manager->setError($id, 1);
+        }
+      }
+    }
+  }
+
+  /**
+   * Callback when batch process is done.
+   */
+  public static function processFinished($success, $results, $operations) {
+    if ($success) {
+      \Drupal::messenger()->addMessage(t('@count items processed', ['@count' => count($results)]));
+    }
+    else {
+      \Drupal::messenger()->addMessage(t('An error occured'), 'error');
+    }
+  }
+
+  /**
+   * Index a single entity.
+   */
+  protected static function indexEntity($entity) {
+    /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $index_manager */
+    $index_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
+
+    foreach ($index_manager->getDefinitions() as $plugin) {
+      if (isset($plugin['entityType']) && $entity->getEntityTypeId() == $plugin['entityType']) {
+        if (!empty($plugin['bundle']) && $plugin['bundle'] != $entity->bundle()) {
+          // Do not index if defined plugin bundle differs from entity bundle.
+          continue;
+        }
+
+        try {
+          $index_manager->createInstance($plugin['id'])->index($entity);
+          return TRUE;
+        }
+        catch (ElasticsearchException $e) {
+          return FALSE;
+        }
+      }
+    }
+  }
+
+}

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchBatchManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchBatchManager.php
@@ -24,16 +24,18 @@ class ElasticsearchBatchManager {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $entity_type_manager = \Drupal::service('entity_type.manager');
 
-    if ($item = $queue_manager->getItem($id)) {
-      if ($entity = $entity_type_manager->getStorage($item->entity_type)->load($item->entity_id)) {
-        if (self::indexEntity($entity)) {
-          $queue_manager->setStatus($id, 1);
-          $queue_manager->setError($id, 0);
-          $context['results'][] = $id;
-        }
-        else {
-          $queue_manager->setError($id, 1);
-        }
+    // Get one item from queue.
+    $item = $queue_manager->getItem($id);
+
+    // Attempt to index the entity to ES.
+    if ($item && $entity = $entity_type_manager->getStorage($item->entity_type)->load($item->entity_id)) {
+      if (self::indexEntity($entity)) {
+        $queue_manager->setStatus($id, 1);
+        $queue_manager->setError($id, 0);
+        $context['results'][] = $id;
+      }
+      else {
+        $queue_manager->setError($id, 1);
       }
     }
   }

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchBatchManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchBatchManager.php
@@ -59,6 +59,7 @@ class ElasticsearchBatchManager {
     /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $index_manager */
     $index_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
 
+    $has_error = FALSE;
     foreach ($index_manager->getDefinitions() as $plugin) {
       if (isset($plugin['entityType']) && $entity->getEntityTypeId() == $plugin['entityType']) {
         if (!empty($plugin['bundle']) && $plugin['bundle'] != $entity->bundle()) {
@@ -68,13 +69,14 @@ class ElasticsearchBatchManager {
 
         try {
           $index_manager->createInstance($plugin['id'])->index($entity);
-          return TRUE;
         }
         catch (ElasticsearchException $e) {
-          return FALSE;
+          $has_error = TRUE;
         }
       }
     }
+
+    return !$has_error;
   }
 
 }

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
@@ -106,7 +106,6 @@ class ElasticsearchQueueManager implements ElasticsearchQueueManagerInterface {
    */
   public function addAll($index_id) {
     $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
-    // @TODO; validate definition.
 
     $storage = $this->entityTypeManager->getStorage($definition['entityType']);
 
@@ -130,7 +129,6 @@ class ElasticsearchQueueManager implements ElasticsearchQueueManagerInterface {
       }
       catch (IntegrityConstraintViolationException $e) {
         // Skip duplicates.
-        // @TODO; log this
       }
     }
   }

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management;
+
+use Drupal\Core\Database\Driver\mysql\Connection;
+use Drupal\Core\Database\IntegrityConstraintViolationException;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager;
+
+/**
+ * Class ElasticsearchQueueManager.
+ */
+class ElasticsearchQueueManager implements ElasticsearchQueueManagerInterface {
+
+  /**
+   * Drupal\Core\Database\Driver\mysql\Connection definition.
+   *
+   * @var \Drupal\Core\Database\Driver\mysql\Connection
+   */
+  protected $database;
+
+  /**
+   * Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager definition.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
+   */
+  protected $pluginManagerElasticsearchIndexProcessor;
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Database table name.
+   *
+   * @var string
+   */
+  protected $table = 'es_reindex_queue';
+
+  /**
+   * Constructs a new ElasticsearchQueueManager object.
+   */
+  public function __construct(Connection $database, ElasticsearchIndexManager $plugin_manager_elasticsearch_index_processor, EntityTypeManagerInterface $entity_type_manager) {
+    $this->database = $database;
+    $this->pluginManagerElasticsearchIndexProcessor = $plugin_manager_elasticsearch_index_processor;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStatus($index_id) {
+    return [
+      'total' => $this->getTotal($index_id),
+      'processed' => $this->getProcessed($index_id),
+      'errors' => $this->getTotalErrors($index_id),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTotal($index_id) {
+    $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
+
+    $query = $this->database->select($this->table);
+    $query->condition('plugin_id', $definition['id']);
+    $query->condition('entity_type', $definition['entityType']);
+
+    return $query->countQuery()->execute()->fetchField();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getProcessed($index_id) {
+    $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
+
+    $query = $this->database->select($this->table);
+    $query->condition('plugin_id', $definition['id']);
+    $query->condition('entity_type', $definition['entityType']);
+    $query->condition('status', 1);
+
+    return $query->countQuery()->execute()->fetchField();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTotalErrors($index_id) {
+    $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
+
+    $query = $this->database->select($this->table);
+    $query->condition('plugin_id', $definition['id']);
+    $query->condition('entity_type', $definition['entityType']);
+    $query->condition('error', 1);
+
+    return $query->countQuery()->execute()->fetchField();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addAll($index_id) {
+    $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
+    // @TODO; validate definition.
+
+    $storage = $this->entityTypeManager->getStorage($definition['entityType']);
+
+    if (isset($definition['bundle'])) {
+      $entities = $storage->loadByProperties(['bundle' => [$definition['bundle']]]);
+    }
+    else {
+      $entities = $storage->loadMultiple();
+    }
+
+    foreach ($entities as $entity) {
+      $query = $this->database->insert($this->table);
+      $query->fields([
+        'plugin_id' => $definition['id'],
+        'entity_type' => $definition['entityType'],
+        'entity_id' => $entity->id(),
+      ]);
+
+      try {
+        $query->execute();
+      }
+      catch (IntegrityConstraintViolationException $e) {
+        // Skip duplicates.
+        // @TODO; log this
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function clear($index_id) {
+    $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
+
+    $query = $this->database->delete($this->table);
+
+    $query->condition('plugin_id', $definition['id']);
+    $query->condition('entity_type', $definition['entityType']);
+
+    $query->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getItems($index_id) {
+    $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
+
+    $query = $this->database->select($this->table, 'queue');
+    $query->fields('queue', ['id', 'status', 'error']);
+
+    $query->condition('plugin_id', $definition['id']);
+    $query->condition('entity_type', $definition['entityType']);
+
+    return $query->execute()->fetchAll();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getItem($id) {
+    $query = $this->database->select($this->table, 'queue');
+    $query->fields('queue', [
+      'id',
+      'entity_type',
+      'entity_id',
+      'error',
+      'status',
+    ]);
+    $query->condition('id', $id);
+
+    return $query->execute()->fetchObject();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setStatus($id, $status) {
+    $query = $this->database->update($this->table);
+    $query->condition('id', $id);
+    $query->fields(['status' => (int) $status]);
+    return $query->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setError($id, $error = 1) {
+    $query = $this->database->update($this->table);
+    $query->condition('id', $id);
+    $query->fields(['error' => (int) $error]);
+    return $query->execute();
+  }
+
+}

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
@@ -107,21 +107,26 @@ class ElasticsearchQueueManager implements ElasticsearchQueueManagerInterface {
   public function addAll($index_id) {
     $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
 
-    $storage = $this->entityTypeManager->getStorage($definition['entityType']);
+    $query = $this
+      ->entityTypeManager
+      ->getStorage($definition['entityType'])
+      ->getQuery();
 
     if (isset($definition['bundle'])) {
-      $entities = $storage->loadByProperties(['bundle' => [$definition['bundle']]]);
+      $entities = $query
+        ->condition('bundle', $definition['bundle'])
+        ->execute();
     }
     else {
-      $entities = $storage->loadMultiple();
+      $entities = $query->execute();
     }
 
-    foreach ($entities as $entity) {
+    foreach ($entities as $entity_id) {
       $query = $this->database->insert($this->table);
       $query->fields([
         'plugin_id' => $definition['id'],
         'entity_type' => $definition['entityType'],
-        'entity_id' => $entity->id(),
+        'entity_id' => $entity_id,
       ]);
 
       try {

--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManagerInterface.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManagerInterface.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management;
+
+/**
+ * Interface ElasticsearchQueueManagerInterface.
+ */
+interface ElasticsearchQueueManagerInterface {
+
+  /**
+   * Get the current queue status of the index.
+   *
+   * @param string $index_id
+   *   The plugin index id.
+   */
+  public function getStatus($index_id);
+
+  /**
+   * Get total items count.
+   *
+   * @param string $index_id
+   *   The plugin index id.
+   */
+  public function getTotal($index_id);
+
+  /**
+   * Get total processed items count.
+   *
+   * @param string $index_id
+   *   The plugin index id.
+   */
+  public function getProcessed($index_id);
+
+  /**
+   * Get total number of items that has errors.
+   */
+  public function getTotalErrors($index_id);
+
+  /**
+   * Add all items from index to queue.
+   *
+   * @param string $index_id
+   *   The plugin index id.
+   */
+  public function addAll($index_id);
+
+  /**
+   * Clear all items from queue.
+   *
+   * @param string $index_id
+   *   The plugin index id.
+   */
+  public function clear($index_id);
+
+  /**
+   * Get items from queue.
+   *
+   * @param string $index_id
+   *   The plugin index id.
+   *
+   * @return array
+   *   Array of queue items.
+   */
+  public function getItems($index_id);
+
+  /**
+   * Get one item from queue.
+   *
+   * @param int $id
+   *   The id of the queue item.
+   *
+   * @return object
+   *   The queue item.
+   */
+  public function getItem($id);
+
+  /**
+   * Set the status of the queue item.
+   *
+   * @param int $id
+   *   The id of the queue item.
+   * @param int $status
+   *   Status value. 1 or 0.
+   */
+  public function setStatus($id, $status);
+
+  /**
+   * Set the status of the queue item.
+   *
+   * @param int $id
+   *   The id of the queue item.
+   * @param int $error
+   *   Error status value. 1 or 0.
+   */
+  public function setError($id, $error);
+
+}

--- a/modules/elasticsearch_helper_index_management/tests/modules/elasticsearch_helper_index_management_test/elasticsearch_helper_index_management_test.info.yml
+++ b/modules/elasticsearch_helper_index_management/tests/modules/elasticsearch_helper_index_management_test/elasticsearch_helper_index_management_test.info.yml
@@ -1,0 +1,5 @@
+name: Elasticsearch helper index management test
+type: module
+description: Module for Elasticsearch Helper Index management tests
+core: 8.x
+package: Testing

--- a/modules/elasticsearch_helper_index_management/tests/modules/elasticsearch_helper_index_management_test/src/Plugin/Elasticsearchindex/TestIndex.php
+++ b/modules/elasticsearch_helper_index_management/tests/modules/elasticsearch_helper_index_management_test/src/Plugin/Elasticsearchindex/TestIndex.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_index_management_test\Plugin\ElasticsearchIndex;
+
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
+
+/**
+ * @ElasticsearchIndex(
+ *   id = "simple_test_node_index",
+ *   label = @Translation("Simple Test Node Index"),
+ *   indexName = "simple_test_node_index",
+ *   typeName = "node",
+ *   entityType = "node"
+ * )
+ */
+class SimpleNodeIndex extends ElasticsearchIndexBase {
+}

--- a/modules/elasticsearch_helper_index_management/tests/src/Kernel/QueueManagerTest.php
+++ b/modules/elasticsearch_helper_index_management/tests/src/Kernel/QueueManagerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\elasticsearch_helper_index_management\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests the Queue Manager Service.
+ *
+ * @group elasticsearch_helper_index_manager
+ */
+class QueueManagerTest extends KernelTestBase {
+
+  /**
+   * Batch manager service.
+   *
+   * @var Drupal\elasticsearch_helper_index_management\ElasticsearchBatchManager
+   */
+  protected $batchManager;
+
+  /**
+   * Test dependency modules.
+   *
+   * @var string[]
+   */
+  public static $modules = [
+    'system',
+    'elasticsearch_helper',
+    'elasticsearch_helper_index_management',
+    'elasticsearch_helper_index_management_test',
+  ];
+
+  /**
+   * Setup the tests.
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->installSchema('elasticsearch_helper_index_management', ['es_reindex_queue']);
+    $this->installConfig(['elasticsearch_helper_index_management']);
+
+    $this->batchManager = \Drupal::service('elasticsearch_helper_index_management.queue_manager');
+
+    $query = \Drupal::service('database')->insert('es_reindex_queue');
+    $query->fields([
+      'plugin_id' => 'simple_test_node_index',
+      'entity_type' => 'node',
+      'entity_id' => 1,
+    ]);
+    $query->execute();
+  }
+
+  /**
+   * Test getStatus() method.
+   */
+  public function testStatus() {
+    $this->assertEqual(
+      $this->batchManager->getStatus('simple_test_node_index'),
+      [
+        'total' => 1,
+        'processed' => 0,
+        'errors' => 0,
+      ]
+    );
+  }
+
+  /**
+   * Test setStatus() method.
+   */
+  public function testSetStatus() {
+    $this->batchManager->setStatus(1, 1);
+
+    $this->assertEqual(
+      $this->batchManager->getStatus('simple_test_node_index'),
+      [
+        'total' => 1,
+        'processed' => 1,
+        'errors' => 0,
+      ]
+    );
+  }
+
+  /**
+   * Test setError() method.
+   */
+  public function testSetError() {
+    $this->batchManager->setError(1);
+
+    $this->assertEqual(
+      $this->batchManager->getStatus('simple_test_node_index'),
+      [
+        'total' => 1,
+        'processed' => 0,
+        'errors' => 1,
+      ]
+    );
+
+    $this->assertEqual(1, $this->batchManager->getTotalErrors('simple_test_node_index'));
+  }
+
+  /**
+   * Test getItem() method.
+   */
+  public function testGetItem() {
+    $item = $this->batchManager->getItem(1);
+
+    $this->assertEqual($item->entity_type, 'node');
+    $this->assertEqual($item->entity_id, 1);
+  }
+
+  /**
+   * Test getItems() method.
+   */
+  public function testGetItems() {
+    $items = $this->batchManager->getItems('simple_test_node_index');
+
+    $this->assertTrue(count($items) == 1);
+  }
+
+}


### PR DESCRIPTION
### Description

This change introduces 2 new modules for managing re-indexing through an administrator UI interface and managing index-version and aliases.

This also aims to solve the following common issues of re-indexing with elasticsearch_helper module:
1. Duplicate entity record in queues when re-index is executed twice, causing double re-indexing of the same entities.
2. When an error occurs during re-indexing (ie. Node going down), the item is removed from the queue and it is not possible to re-index only the entities which has failed.
3. Downtime when re-indexing after mapping changes

### Testing

##### Aliases and Index version
1. Copy and modify the versioned index example `elasticsearch_helper/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php`
2. Enable `elasticsearch_helper_index_alias`
3. Run `drush eshs` to initially setup the index without version.
4. Verify that the new index was created.
5. Login as Drupal admin and go to the Aliases management `/elasticsearch_helper_index_management/indices`
6. From the Alias management, increment the version number
7. Run `drush eshs` to setup the new index and mapping
8. The new index should have the correct version
9. From the Alias management, update the alias to point to the index version
10. Verify that aliases are pointing to the new index version

##### Re-indexing
1. Login as Drupal admin and go to the Aliases management `/elasticsearch_helper_index_management/indices`
2. It should list the current index plugins
3. Click manage from one of the index on the list
4. Click "Queue all for re-indexing" to queue entities for re-indexing
5. Click "Batch process all queue items" to start the re-index process
6. It should create a batch process
7. Verify that entities are indexed

### TODOS

- DOCS
- Readmes
- More tests