### PR TITLE
Bundle key is retrieved from entity type definition

### DIFF
--- a/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
+++ b/modules/elasticsearch_helper_index_management/src/ElasticsearchQueueManager.php
@@ -106,15 +106,14 @@ class ElasticsearchQueueManager implements ElasticsearchQueueManagerInterface {
    */
   public function addAll($index_id) {
     $definition = $this->pluginManagerElasticsearchIndexProcessor->getDefinition($index_id);
-
-    $query = $this
-      ->entityTypeManager
-      ->getStorage($definition['entityType'])
-      ->getQuery();
+    $storage = $this->entityTypeManager->getStorage($definition['entityType']);
+    $query = $storage->getQuery();
 
     if (isset($definition['bundle'])) {
+      $bundle_key = $this->entityTypeManager->getDefinition($definition['entityType'])->getKey('bundle');
+
       $entities = $query
-        ->condition('bundle', $definition['bundle'])
+        ->condition($bundle_key, $definition['bundle'])
         ->execute();
     }
     else {


### PR DESCRIPTION
This change fixes the bug where an exception would be thrown if entity bundle key is something else than `bundle`.

**Problem**
When `Queue all for re-indexing` action link is clicked, an exception is thrown if entity type being re-indexed has bundle key other than `bundle`, for example, `node` entity type which has `type` as bundle key or `taxonomy_term` entity type which has `vid` as bundle key.

**Solution**
Retrieve the bundle key from entity type definition and use the key for querying relevant entities.