### PR TITLE
Only indices that are related to an entity type are displayed on index management page

### DIFF
--- a/modules/elasticsearch_helper_index_management/src/Controller/ListController.php
+++ b/modules/elasticsearch_helper_index_management/src/Controller/ListController.php
@@ -38,7 +38,7 @@ class ListController extends ControllerBase {
   /**
    * List index plugins.
    *
-   * @return string
+   * @return array
    *   List markup.
    */
   public function display() {
@@ -54,19 +54,21 @@ class ListController extends ControllerBase {
     $rows = [];
 
     foreach ($this->elasticsearchHelperPluginManager->getDefinitions() as $plugin) {
-      $action = Link::createFromRoute(
-        $this->t('Manage'),
-        'elasticsearch_helper_index_management.reindex_controller_status',
-        ['index_id' => $plugin['id']],
-        ['attributes' => ['class' => 'button']]
-      );
+      if (isset($plugin['entityType'])) {
+        $action = Link::createFromRoute(
+          $this->t('Manage'),
+          'elasticsearch_helper_index_management.reindex_controller_status',
+          ['index_id' => $plugin['id']],
+          ['attributes' => ['class' => 'button']]
+        );
 
-      $rows[] = [
-        $plugin['label'],
-        $plugin['id'],
-        $plugin['entityType'],
-        $action,
-      ];
+        $rows[] = [
+          $plugin['label'],
+          $plugin['id'],
+          $plugin['entityType'],
+          $action,
+        ];
+      }
     }
 
     return [

--- a/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
+++ b/modules/elasticsearch_helper_index_management/src/Controller/ReindexController.php
@@ -51,7 +51,7 @@ class ReindexController extends ControllerBase {
    * @param string $index_id
    *   The index plugin id.
    *
-   * @return string
+   * @return array
    *   Status markup.
    */
   public function status($index_id) {


### PR DESCRIPTION
**Problem**
Given that index management module works only with indices that are related to an entity type,
a lot of errors are displayed on index management page if there are indices that do not index entities of particulat entity type.

**Solution**
List only indices that are related to an entity type.