### PR TITLE
Issue #3116938: Uncaught TypeError in the ElasticsearchContentNormalizer constructor

### DIFF
--- a/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
+++ b/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
@@ -3,7 +3,7 @@ services:
     class: Drupal\elasticsearch_helper_content\Plugin\Normalizer\ElasticsearchContentNormalizer
     tags:
       - { name: normalizer, priority: 50 }
-    arguments: ['@entity.manager', '@entity_type.manager', '@config.factory', '@renderer', '@theme.manager', '@theme.initialization', '@language_manager', '@entity_type.bundle.info']
+    arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager', '@config.factory', '@renderer', '@theme.manager', '@theme.initialization', '@language_manager', '@entity_type.bundle.info']
 
   logger.channel.elasticsearch_helper_content:
     parent: logger.channel_base

--- a/modules/elasticsearch_helper_content/src/Plugin/Normalizer/ElasticsearchContentNormalizer.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/Normalizer/ElasticsearchContentNormalizer.php
@@ -2,14 +2,15 @@
 
 namespace Drupal\elasticsearch_helper_content\Plugin\Normalizer;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityTypeRepositoryInterface;
 use Drupal\Core\Language\LanguageManager;
 use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\serialization\Normalizer\ContentEntityNormalizer;
 use Drupal\Core\Theme\ThemeManager;
 use Drupal\Core\Theme\ThemeInitialization;
-use Drupal\Core\Entity\EntityTypeManager;
-use Drupal\core\Entity\EntityManagerInterface;
 use Drupal\core\Entity\ContentEntityBase;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\Config\ConfigFactory;
@@ -101,8 +102,9 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
    * Constructs a new FilefieldDownloader object.
    */
   public function __construct(
-    EntityManagerInterface $entity_manager,
-    EntityTypeManager $entity_type_manager,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityTypeRepositoryInterface $entity_type_repository,
+    EntityFieldManagerInterface $entity_field_manager,
     ConfigFactory $config_factory,
     Renderer $renderer,
     ThemeManager $theme_manager,
@@ -110,7 +112,7 @@ class ElasticsearchContentNormalizer extends ContentEntityNormalizer {
     LanguageManager $language_manager,
     EntityTypeBundleInfo $entity_type_bundle_info
   ) {
-    parent::__construct($entity_manager);
+    parent::__construct($entity_type_manager, $entity_type_repository, $entity_field_manager);
     $this->entityTypeManager = $entity_type_manager;
     $this->configFactory = $config_factory;
     $this->renderer = $renderer;


### PR DESCRIPTION
This PR fixes uncaught TypeError in the ElasticsearchContentNormalizer constructor in elasticsearch_helper_content module while enabling profiler.

Addresses Drupal 9 readiness issue at the same time as EntityNormalizer constructor says:
```
  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeRepositoryInterface $entity_type_repository = NULL, EntityFieldManagerInterface $entity_field_manager = NULL) {
    $this->entityTypeManager = $entity_type_manager;
    if (!$entity_type_repository) {
      @trigger_error('The entity_type.repository service must be passed to EntityNormalizer::__construct(), it is required before Drupal 9.0.0. See https://www.drupal.org/node/2549139.', E_USER_DEPRECATED);**
      $entity_type_repository = \Drupal::service('entity_type.repository');
    }
    $this->entityTypeRepository = $entity_type_repository;
    if (!$entity_field_manager) {
      @trigger_error('The entity_field.manager service must be passed to EntityNormalizer::__construct(), it is required before Drupal 9.0.0. See https://www.drupal.org/node/2549139.', E_USER_DEPRECATED);**
      $entity_field_manager = \Drupal::service('entity_field.manager');
    }
    $this->entityFieldManager = $entity_field_manager;
  }
```