### PR TITLE
8.x 7.x

### DIFF
--- a/elasticsearch_helper.info.yml
+++ b/elasticsearch_helper.info.yml
@@ -1,7 +1,7 @@
 name: ElasticSearch Helper
 type: module
 description: Provide tools to integrate elasticsearch with Drupal.
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 package: ElasticSearch Helper
 configure: elasticsearch_helper.elasticsearch_helper_settings_form
 dependencies:

--- a/examples/elasticsearch_helper_example/elasticsearch_helper_example.info.yml
+++ b/examples/elasticsearch_helper_example/elasticsearch_helper_example.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Example
 type: module
 description: Example plugin implementation for the Elasticsearch Helper module.
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 hidden: true
 dependencies:
 - elasticsearch_helper

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -9,7 +9,6 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  *   id = "simple_node_index",
  *   label = @Translation("Simple Node Index"),
  *   indexName = "simple",
- *   typeName = "node",
  *   entityType = "node"
  * )
  */

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -9,7 +9,6 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  *   id = "time_based_index",
  *   label = @Translation("Example Time-based Index"),
  *   indexName = "time-based-{year}{month}",
- *   typeName = "node",
  *   entityType = "node"
  * )
  */

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/VersionedIndex.php
@@ -11,7 +11,6 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  *   id = "versioned_example_index",
  *   label = @Translation("Example Versioned Index"),
  *   indexName = "versioned_example{version}",
- *   typeName = "node",
  *   entityType = "node",
  *   versioned = TRUE
  * )
@@ -48,14 +47,15 @@ class VersionedIndex extends ElasticsearchIndexBase {
       $this->client->indices()->create([
         'index' => $index_name,
         'body' => [
-          'number_of_shards' => 1,
-          'number_of_replicas' => 1,
+          'settings' => [
+            'number_of_shards' => 1,
+            'number_of_replicas' => 1,
+          ],
         ],
       ]);
 
       $this->client->indices()->putMapping([
         'index' => $index_name,
-        'type' => 'node',
         'body' => [
           'properties' => [
             'title' => [

--- a/modules/elasticsearch_helper_content/elasticsearch_helper_content.info.yml
+++ b/modules/elasticsearch_helper_content/elasticsearch_helper_content.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Content
 type: module
 description: Versatile generic elasticsearch indexing for typical content entities.
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 package: ElasticSearch Helper
 dependencies:
   - elasticsearch_helper

--- a/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
+++ b/modules/elasticsearch_helper_content/elasticsearch_helper_content.services.yml
@@ -3,7 +3,7 @@ services:
     class: Drupal\elasticsearch_helper_content\Plugin\Normalizer\ElasticsearchContentNormalizer
     tags:
       - { name: normalizer, priority: 50 }
-    arguments: ['@entity.manager', '@entity_type.manager', '@config.factory', '@renderer', '@theme.manager', '@theme.initialization', '@language_manager', '@entity_type.bundle.info']
+    arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager', '@config.factory', '@renderer', '@theme.manager', '@theme.initialization', '@language_manager', '@entity_type.bundle.info', '@entity_display.repository']
 
   logger.channel.elasticsearch_helper_content:
     parent: logger.channel_base

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchIndex/NodeIndex.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchIndex/NodeIndex.php
@@ -7,7 +7,6 @@ namespace Drupal\elasticsearch_helper_content\Plugin\ElasticsearchIndex;
  *   id = "content_index_node",
  *   label = @Translation("Node Index (Multilingual)"),
  *   indexName = "content-node-{langcode}",
- *   typeName = "node",
  *   entityType = "node"
  * )
  */
@@ -25,4 +24,5 @@ class NodeIndex extends MultilingualContentIndex {
    * MultilingualContentIndex.
    *
    */
+
 }

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchIndex/TermIndex.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchIndex/TermIndex.php
@@ -7,7 +7,6 @@ namespace Drupal\elasticsearch_helper_content\Plugin\ElasticsearchIndex;
  *   id = "content_index_term",
  *   label = @Translation("Topics Index (Multilingual)"),
  *   indexName = "content-topics-{langcode}",
- *   typeName = "taxonomy_term",
  *   entityType = "taxonomy_term",
  * )
  */

--- a/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchIndex/UserIndex.php
+++ b/modules/elasticsearch_helper_content/src/Plugin/ElasticsearchIndex/UserIndex.php
@@ -9,7 +9,6 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  *   id = "content_index_user",
  *   label = @Translation("User Index"),
  *   indexName = "content-user",
- *   typeName = "user",
  *   entityType = "user"
  * )
  */

--- a/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.info.yml
+++ b/modules/elasticsearch_helper_index_alias/elasticsearch_helper_index_alias.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Index Alias
 type: module
 description: A module which adds index versioning and alias features
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 dependencies:
   - elasticsearch_helper
   - elasticsearch_helper_index_management

--- a/modules/elasticsearch_helper_instant/elasticsearch_helper_instant.info.yml
+++ b/modules/elasticsearch_helper_instant/elasticsearch_helper_instant.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Instant
 type: module
 description: Instant search functionality based on elasticssearch_helper_content.module.
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 package: ElasticSearch Helper
 dependencies:
   - elasticsearch_helper

--- a/modules/elasticsearch_helper_instant/js/elasticsearch-helper-instant.js
+++ b/modules/elasticsearch_helper_instant/js/elasticsearch-helper-instant.js
@@ -98,4 +98,3 @@
   };
 
 })(jQuery, Drupal);
-

--- a/modules/elasticsearch_helper_instant/src/ElasticsearchInstantSearchService.php
+++ b/modules/elasticsearch_helper_instant/src/ElasticsearchInstantSearchService.php
@@ -107,8 +107,8 @@ class ElasticsearchInstantSearchService {
     $result['searchphrase'] = $searchphrase;
     $result['query'] = $query;
 
-    foreach($result['hits']['hits'] ?? [] as $index => $hit) {
-       $this->modifySearchResult($result['hits']['hits'][$index]['_source']);
+    foreach ($result['hits']['hits'] ?? [] as $index => $hit) {
+      $this->modifySearchResult($result['hits']['hits'][$index]['_source']);
     }
 
     return $result;
@@ -134,6 +134,7 @@ class ElasticsearchInstantSearchService {
    *   The search phrase to create a query for.
    * @param string $langcode
    *   The language code to retrieve search results in.
+   *
    * @return array
    *   The query as an array.
    */

--- a/modules/elasticsearch_helper_views/elasticsearch_helper_views.info.yml
+++ b/modules/elasticsearch_helper_views/elasticsearch_helper_views.info.yml
@@ -1,7 +1,7 @@
 name: ElasticSearch Helper Views
 type: module
 description: Provides tools to integrate elasticsearch with Drupal Views.
-core: 8.x
+core_version_requirement: ^8.8.0 || ^9
 package: ElasticSearch Helper
 dependencies:
   - elasticsearch_helper

--- a/modules/elasticsearch_helper_views/src/Plugin/views/field/RenderedEntity.php
+++ b/modules/elasticsearch_helper_views/src/Plugin/views/field/RenderedEntity.php
@@ -5,11 +5,12 @@ namespace Drupal\elasticsearch_helper_views\Plugin\views\field;
 use Drupal\Component\Serialization\Yaml;
 use Drupal\Core\Cache\CacheableDependencyInterface;
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\DependencyInjection\DeprecatedServicePropertyTrait;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\views\Entity\Render\EntityTranslationRenderTrait;
@@ -28,9 +29,10 @@ use Drupal\Core\Cache\Cache;
 class RenderedEntity extends FieldPluginBase implements CacheableDependencyInterface {
 
   use EntityTranslationRenderTrait;
+  use DeprecatedServicePropertyTrait;
 
-  /** @var \Drupal\Core\Entity\EntityManagerInterface $entityManager */
-  protected $entityManager;
+  /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager */
+  protected $entityTypeManager;
 
   /** @var \Drupal\Core\Language\LanguageManagerInterface $languageManager */
   protected $languageManager;
@@ -47,14 +49,14 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
    * @param array $configuration
    * @param string $plugin_id
    * @param array $plugin_definition
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
    */
-  public function __construct(array $configuration, $plugin_id, array $plugin_definition, EntityManagerInterface $entity_manager, LanguageManagerInterface $language_manager, EntityDisplayRepositoryInterface $entity_display_repository) {
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entity_manager, LanguageManagerInterface $language_manager, EntityDisplayRepositoryInterface $entity_display_repository) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
-    $this->entityManager = $entity_manager;
+    $this->entityTypeManager = $entity_manager;
     $this->languageManager = $language_manager;
     $this->entityDisplayRepository = $entity_display_repository;
   }
@@ -67,7 +69,7 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('entity.manager'),
+      $container->get('entity_type.manager'),
       $container->get('language_manager'),
       $container->get('entity_display.repository')
     );
@@ -80,7 +82,7 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
    */
   protected function getContentEntityTypes() {
     $entity_types = [];
-    foreach ($this->entityManager->getDefinitions() as $entity_type) {
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
       // Filter out content entity types.
       if ($entity_type instanceof ContentEntityTypeInterface) {
         $entity_types[$entity_type->id()] = $entity_type->getLabel();
@@ -188,7 +190,7 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
         }
 
         // Build entity view.
-        $view_builder = $this->entityManager->getViewBuilder($entity_type);
+        $view_builder = $this->entityTypeManager->getViewBuilder($entity_type);
         $build += $view_builder->view($entity, $view_mode);
 
         // Add cache contexts to the build.
@@ -254,7 +256,7 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
    * {@inheritdoc}
    */
   public function getCacheTags() {
-    $view_display_storage = $this->entityManager->getStorage('entity_view_display');
+    $view_display_storage = $this->entityTypeManager->getStorage('entity_view_display');
     $view_displays = $view_display_storage->loadMultiple($view_display_storage
       ->getQuery()
       ->condition('targetEntityType', $this->getEntityTypeId())
@@ -302,7 +304,16 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
    * {@inheritdoc}
    */
   protected function getEntityManager() {
+    // This relies on DeprecatedServicePropertyTrait to trigger a deprecation
+    // message in case it is accessed.
     return $this->entityManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEntityTypeManager() {
+    return $this->entityTypeManager;
   }
 
   /**

--- a/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
+++ b/modules/elasticsearch_helper_views/src/Plugin/views/query/Elasticsearch.php
@@ -340,7 +340,7 @@ class Elasticsearch extends QueryPluginBase {
     $view->result = $result;
 
     $view->pager->postExecute($view->result);
-    $view->pager->total_items = isset($data['hits']['total']) ? $data['hits']['total'] : 0;
+    $view->pager->total_items = isset($data['hits']['total']['value']) ? $data['hits']['total']['value'] : 0;
     // Account for offset when calculating total results.
     if (!empty($view->pager->options['offset'])) {
       // Make sure that total is never negative.

--- a/src/Commands/ElasticsearchHelperCommands.php
+++ b/src/Commands/ElasticsearchHelperCommands.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\elasticsearch_helper\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -72,7 +72,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
     try {
       $health = $this->client->cluster()->health();
 
-      drupal_set_message($this->t('Connected to Elasticsearch'));
+      $this->messenger()->addMessage($this->t('Connected to Elasticsearch'));
 
       $color_states = [
         'green' => 'status',
@@ -80,15 +80,15 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
         'red' => 'error',
       ];
 
-      drupal_set_message($this->t('Elasticsearch cluster status is @status', [
+      $this->messenger()->addMessage($this->t('Elasticsearch cluster status is @status', [
         '@status' => $health['status'],
       ]), $color_states[$health['status']]);
     }
     catch (NoNodesAvailableException $e) {
-      drupal_set_message($this->t('Could not connect to Elasticsearch'), 'error');
+      $this->messenger()->addError($this->t('Could not connect to Elasticsearch'));
     }
     catch (\Exception $e) {
-      drupal_set_message($e->getMessage(), 'error');
+      $this->messenger()->addError($e->getMessage());
     }
 
     $form['scheme'] = [

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -4,6 +4,7 @@ namespace Drupal\elasticsearch_helper\Plugin;
 
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Elasticsearch\Client;
@@ -35,6 +36,13 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   protected $logger;
 
   /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * The regular expression used to identify placeholders in index and type names.
    *
    * @var string
@@ -49,13 +57,15 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @param \Elasticsearch\Client $client
    * @param \Symfony\Component\Serializer\Serializer $serializer
    * @param \Psr\Log\LoggerInterface $logger
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Client $client, Serializer $serializer, LoggerInterface $logger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Client $client, Serializer $serializer, LoggerInterface $logger, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->client = $client;
     $this->serializer = $serializer;
     $this->logger = $logger;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -72,7 +82,8 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $plugin_definition,
       $container->get('elasticsearch_helper.elasticsearch_client'),
       $container->get('serializer'),
-      $container->get('logger.factory')->get('elasticsearch_helper')
+      $container->get('logger.factory')->get('elasticsearch_helper'),
+      $container->get('messenger')
     );
   }
 
@@ -119,7 +130,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       if ($indices = $this->client->indices()->get($params)) {
         // Notify user that indices have been deleted.
         foreach ($indices as $indexName => $index) {
-          drupal_set_message($this->t('Index @indexName has been deleted.', ['@indexName' => $indexName]));
+          $this->messenger->addStatus($this->t('Index @indexName has been deleted.', ['@indexName' => $indexName]));
         }
 
         // Delete matching indices.
@@ -127,7 +138,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (Missing404Exception $e) {
-      drupal_set_message($this->t('No Elasticsearch index matching @pattern could be dropped.', [
+      $this->messenger->addStatus($this->t('No Elasticsearch index matching @pattern could be dropped.', [
         '@pattern' => $this->indexNamePattern(),
       ]));
     }

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -152,7 +152,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
     $params = [
       'index' => $this->getIndexName($serialized_data),
-      'type' => $this->getTypeName($serialized_data),
       'body' => $serialized_data,
     ];
 
@@ -171,7 +170,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
     $params = [
       'index' => $this->getIndexName($serialized_data),
-      'type' => $this->getTypeName($serialized_data),
       'id' => $this->getId($serialized_data),
     ];
 
@@ -186,7 +184,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
     $params = [
       'index' => $this->getIndexName($serialized_data),
-      'type' => $this->getTypeName($serialized_data),
       'id' => $this->getId($serialized_data),
       'body' => [
         'doc' => $serialized_data,
@@ -205,7 +202,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
     $params = [
       'index' => $this->getIndexName($serialized_data),
-      'type' => $this->getTypeName($serialized_data),
       'id' => $this->getId($serialized_data),
     ];
 
@@ -225,7 +221,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   public function search($params) {
     return $this->client->search([
       'index' => $this->indexNamePattern(),
-      'type' => $this->typeNamePattern(),
     ] + $params);
   }
 
@@ -235,7 +230,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   public function msearch($params) {
     return $this->client->msearch([
       'index' => $this->indexNamePattern(),
-      'type' => $this->typeNamePattern(),
     ] + $params);
   }
 
@@ -247,7 +241,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
     $params = [
       'index' => $this->getIndexName($serialized_data),
-      'type' => $this->getTypeName($serialized_data),
       'body' => $serialized_data,
     ];
 
@@ -294,15 +287,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   }
 
   /**
-   * Determine the name of the type where the given data will be indexed.
-   *
-   * @return string
-   */
-  protected function getTypeName($data) {
-    return $this->replacePlaceholders($this->pluginDefinition['typeName'], $data);
-  }
-
-  /**
    * Determine the name of the ID for the elasticsearch entry.
    *
    * @return string
@@ -327,15 +311,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    */
   protected function indexNamePattern() {
     return preg_replace($this->placeholder_regex, '*', $this->pluginDefinition['indexName']);
-  }
-
-  /**
-   * Define a pattern that will match all types.
-   *
-   * @return string
-   */
-  protected function typeNamePattern() {
-    return preg_replace($this->placeholder_regex, '*', $this->pluginDefinition['typeName']);
   }
 
   /**

--- a/tests/src/FunctionalJavascript/EntityOpsTest.php
+++ b/tests/src/FunctionalJavascript/EntityOpsTest.php
@@ -3,14 +3,14 @@
 namespace Drupal\Tests\elasticsearch_helper\FunctionalJavascript;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\FunctionalJavascriptTests\JavascriptTestBase;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 
 /**
  * Test basic functionality.
  *
  * @group elasticsearch_helper
  */
-class EntityOpsTest extends JavascriptTestBase {
+class EntityOpsTest extends WebDriverTestBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
This PR adds (initial) support for Elasticsearch 7.x version

Major changes:
- Removal of mapping types (https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)
- Drupal 9 readiness

Tested with following combinations:
- elasticsearch_helper with elasticsearch_helper_content and elasticsearch_helper_instant
- elasticsearch_helper with elasticsearch_helper_views 
  - Used OPH project (wunderio/client-fi-oph) as a test bench, update from elasticsearch 5.x to elasticsearch 7.x with minor changes) 

Please note that  Elasticsearch-PHP client is suggested rather than required in composer.json and thus, run the following command to add it to the project (along with elasticsearch_helper), for example:
```
composer require elasticsearch/elasticsearch:~7.0
```