### PR TITLE
Drupal 9 readiness

### DIFF
--- a/elasticsearch_helper.info.yml
+++ b/elasticsearch_helper.info.yml
@@ -1,7 +1,7 @@
 name: ElasticSearch Helper
 type: module
 description: Provide tools to integrate elasticsearch with Drupal.
-core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 package: ElasticSearch Helper
 configure: elasticsearch_helper.elasticsearch_helper_settings_form
 dependencies:

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -72,7 +72,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
     try {
       $health = $this->client->cluster()->health();
 
-      drupal_set_message($this->t('Connected to Elasticsearch'));
+      $this->messenger()->addMessage($this->t('Connected to Elasticsearch'));
 
       $color_states = [
         'green' => 'status',
@@ -80,15 +80,15 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
         'red' => 'error',
       ];
 
-      drupal_set_message($this->t('Elasticsearch cluster status is @status', [
+      $this->messenger()->addMessage($this->t('Elasticsearch cluster status is @status', [
         '@status' => $health['status'],
       ]), $color_states[$health['status']]);
     }
     catch (NoNodesAvailableException $e) {
-      drupal_set_message($this->t('Could not connect to Elasticsearch'), 'error');
+      $this->messenger()->addError($this->t('Could not connect to Elasticsearch'));
     }
     catch (\Exception $e) {
-      drupal_set_message($e->getMessage(), 'error');
+      $this->messenger()->addError($e->getMessage());
     }
 
     $form['scheme'] = [

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -4,6 +4,7 @@ namespace Drupal\elasticsearch_helper\Plugin;
 
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Elasticsearch\Client;
@@ -18,6 +19,7 @@ use Psr\Log\LoggerInterface;
 abstract class ElasticsearchIndexBase extends PluginBase implements ElasticsearchIndexInterface, ContainerFactoryPluginInterface {
 
   use StringTranslationTrait;
+  use MessengerTrait;
 
   /**
    * @var \Elasticsearch\Client
@@ -119,7 +121,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       if ($indices = $this->client->indices()->get($params)) {
         // Notify user that indices have been deleted.
         foreach ($indices as $indexName => $index) {
-          drupal_set_message($this->t('Index @indexName has been deleted.', ['@indexName' => $indexName]));
+          $this->messenger()->addStatus($this->t('Index @indexName has been deleted.', ['@indexName' => $indexName]));
         }
 
         // Delete matching indices.
@@ -127,7 +129,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (Missing404Exception $e) {
-      drupal_set_message($this->t('No Elasticsearch index matching @pattern could be dropped.', [
+      $this->messenger()->addStatus($this->t('No Elasticsearch index matching @pattern could be dropped.', [
         '@pattern' => $this->indexNamePattern(),
       ]));
     }

--- a/tests/src/FunctionalJavascript/EntityOpsTest.php
+++ b/tests/src/FunctionalJavascript/EntityOpsTest.php
@@ -3,14 +3,14 @@
 namespace Drupal\Tests\elasticsearch_helper\FunctionalJavascript;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\FunctionalJavascriptTests\JavascriptTestBase;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 
 /**
  * Test basic functionality.
  *
  * @group elasticsearch_helper
  */
-class EntityOpsTest extends JavascriptTestBase {
+class EntityOpsTest extends WebDriverTestBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
This PR adds (initial) support for Elasticsearch 7.x version

Major changes:
- Removal of mapping types (https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)
- Drupal 9 readiness

Tested with following combinations:
- elasticsearch_helper with elasticsearch_helper_content and elasticsearch_helper_instant
- elasticsearch_helper with elasticsearch_helper_views 
  - Used OPH project (wunderio/client-fi-oph) as a test bench, update from elasticsearch 5.x to elasticsearch 7.x with minor changes) 

Please note that  Elasticsearch-PHP client is suggested rather than required in composer.json and thus, run the following command to add it to the project (along with elasticsearch_helper), for example:
```
composer require elasticsearch/elasticsearch:~7.0
```