### PR TITLE
Elasticsearch-PHP library is removed as required package from composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Elasticsearch Helper
 
+## System requirements
+* Drupal >= 8.7.7 or 9.0
+* [Elasticsearch-PHP](https://github.com/elastic/elasticsearch-php) library
+
+## Installation
+
+The module requires [Elasticsearch-PHP](https://github.com/elastic/elasticsearch-php) library to
+communicate with Elasticsearch server. Please make sure you install the version of the library compatible with
+the version of the server (see the [compatibility matrix](https://github.com/elastic/elasticsearch-php#version-matrix)).
+
+To install the library for use with Elasticsearch 7.x:
+```
+composer require elasticsearch/elasticsearch:~7.0
+```
+
+
 ## Drush commands
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,7 @@
 {
     "name": "drupal/elasticsearch_helper",
-    "description": "Provide tools to integrate elasticsearch with Drupal.",
+    "description": "Provide tools to integrate Elasticsearch with Drupal.",
     "type": "drupal-module",
-    "require": {
-        "elasticsearch/elasticsearch": "~6.0"
-    },
     "suggest": {
         "jsq/amazon-es-php": "Amazon elasticseach PHP framework",
         "aws/aws-sdk-php": "Amazon PHP SDK"


### PR DESCRIPTION
- `README.md` updated with instructions how to install the Elasticsearch library manually.