### PR TITLE
Elasticsearch 6 and 7 compatibility layer

### DIFF
--- a/src/Client/ClientBuilder.php
+++ b/src/Client/ClientBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper\Client;
 
+use Drupal\elasticsearch_helper\ElasticsearchClientBuilder;
 use Elasticsearch\Client;
 use Elasticsearch\ClientBuilder as OriginalClientBuilder;
 use Elasticsearch\Transport;
@@ -18,27 +19,9 @@ class ClientBuilder extends OriginalClientBuilder {
    * {@inheritdoc}
    */
   protected function instantiate(Transport $transport, callable $endpoint, array $registeredNamespaces): Client {
-    $class_name = $this->getElasticsearchClientClassName(Client::VERSION);
+    $class_name = ElasticsearchClientBuilder::getElasticsearchClientClassName();
 
     return new $class_name($transport, $endpoint, $registeredNamespaces);
-  }
-
-  /**
-   * Returns Elasticsearch client class name based on provided version.
-   *
-   * @param $version
-   *
-   * @return string|null
-   */
-  protected function getElasticsearchClientClassName($version) {
-    if (version_compare($version, '7.0') >= 0) {
-      return '\Drupal\elasticsearch_helper\Client\Version_7\Client';
-    }
-    elseif (version_compare($version, '5.0') >= 0) {
-      return '\Elasticsearch\Client';
-    }
-
-    return NULL;
   }
 
 }

--- a/src/Client/ClientBuilder.php
+++ b/src/Client/ClientBuilder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Client;
+
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder as OriginalClientBuilder;
+use Elasticsearch\Transport;
+
+/**
+ * Class ClientBuilder
+ */
+class ClientBuilder extends OriginalClientBuilder {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function instantiate(Transport $transport, callable $endpoint, array $registeredNamespaces): Client {
+    $class_name = $this->getElasticsearchClientClassName(Client::VERSION);
+
+    return new $class_name($transport, $endpoint, $registeredNamespaces);
+  }
+
+  /**
+   * Returns Elasticsearch client class name based on provided version.
+   *
+   * @param $version
+   *
+   * @return string|null
+   */
+  protected function getElasticsearchClientClassName($version) {
+    if (version_compare($version, '7.0') >= 0) {
+      return '\Drupal\elasticsearch_helper\Client\Version_7\Client';
+    }
+    elseif (version_compare($version, '5.0') >= 0) {
+      return '\Elasticsearch\Client';
+    }
+
+    return NULL;
+  }
+
+}

--- a/src/Client/ClientBuilder.php
+++ b/src/Client/ClientBuilder.php
@@ -8,6 +8,9 @@ use Elasticsearch\Transport;
 
 /**
  * Class ClientBuilder
+ *
+ * Overrides the original \Elasticsearch\ClientBuilder and returns
+ * overridden \Elasticsearch\Client class.
  */
 class ClientBuilder extends OriginalClientBuilder {
 

--- a/src/Client/Version_7/Client.php
+++ b/src/Client/Version_7/Client.php
@@ -10,17 +10,19 @@ use Drupal\elasticsearch_helper\Client\Version_7\Namespaces\IndicesNamespace;
  * Class Client
  *
  * Elasticsearch Helper 8.x-6.x has been proven to work with Elasticsearch-PHP
- * version 6.x of the box. Elasticsearch-PHP version 7.x introduces deprecation
- * messages in cases when types are provided. In order to support Elasticsearch
- * version 6 and 7, the following client libraries are used when client is
- * built:
- *   - If \Elasticsearch\Client::VERSION is >= 6 and < 7, \Elasticsearch\Client
+ * version 5.x and 6.x out of the box. Elasticsearch-PHP version 7.x introduces
+ * deprecation messages in cases when types are provided. In order to support
+ * Elasticsearch version 6 and 7, the following client libraries are used when
+ * client is built:
+ *   - If \Elasticsearch\Client::VERSION is >= 5 and < 7, \Elasticsearch\Client
  *     class is used.
  *   - If \Elasticsearch\Client::VERSION is >= 7, \Elasticsearch\Client class
  *     override is used (this class). In cases when Elasticsearch index plugins
- *     use legacy parameters originally used for Elasticsearch 6, they are
- *     modified by the override client class to make them compliant to
- *     Elasticsearch 7.
+ *     use legacy parameters originally used for Elasticsearch 6 (e.g, "type"),
+ *     they are modified by the override client class to make them compliant
+ *     with Elasticsearch 7 request syntax.
+ *
+ * @see \Drupal\elasticsearch_helper\Client\ClientBuilder::instantiate()
  */
 class Client extends OriginalClient {
 

--- a/src/Client/Version_7/Client.php
+++ b/src/Client/Version_7/Client.php
@@ -41,8 +41,6 @@ class Client extends OriginalClient {
    */
   protected function __removeType(&$params) {
     if (isset($params['type'])) {
-      @trigger_error('Field "type" should not be defined in provided parameters.', E_USER_DEPRECATED);
-
       unset($params['type']);
     }
   }

--- a/src/Client/Version_7/Client.php
+++ b/src/Client/Version_7/Client.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Client\Version_7;
+
+use Elasticsearch\Client as OriginalClient;
+use Elasticsearch\Transport;
+use Drupal\elasticsearch_helper\Client\Version_7\Namespaces\IndicesNamespace;
+
+/**
+ * Class Client
+ *
+ * Elasticsearch Helper 8.x-6.x has been proven to work with Elasticsearch-PHP
+ * version 6.x of the box. Elasticsearch-PHP version 7.x introduces deprecation
+ * messages in cases when types are provided. In order to support Elasticsearch
+ * version 6 and 7, the following client libraries are used when client is
+ * built:
+ *   - If \Elasticsearch\Client::VERSION is >= 6 and < 7, \Elasticsearch\Client
+ *     class is used.
+ *   - If \Elasticsearch\Client::VERSION is >= 7, \Elasticsearch\Client class
+ *     override is used (this class). In cases when Elasticsearch index plugins
+ *     use legacy parameters originally used for Elasticsearch 6, they are
+ *     modified by the override client class to make them compliant to
+ *     Elasticsearch 7.
+ */
+class Client extends OriginalClient {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(Transport $transport, callable $endpoint, array $registeredNamespaces) {
+    parent::__construct($transport, $endpoint, $registeredNamespaces);
+
+    // Override IndicesNamespace class.
+    $this->indices = new IndicesNamespace($transport, $endpoint);
+  }
+
+  /**
+   * Removes type from parameters.
+   *
+   * @param $params
+   */
+  protected function __removeType(&$params) {
+    if (isset($params['type'])) {
+      @trigger_error('Field "type" should not be defined in provided parameters.', E_USER_DEPRECATED);
+
+      unset($params['type']);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function index(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::index($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::get($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function update(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::update($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::delete($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function search(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::search($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function msearch(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::msearch($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function bulk(array $params = []) {
+    $this->__removeType($params);
+
+    return parent::bulk($params);
+  }
+
+}

--- a/src/Client/Version_7/Namespaces/IndicesNamespace.php
+++ b/src/Client/Version_7/Namespaces/IndicesNamespace.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Client\Version_7\Namespaces;
+
+use Elasticsearch\Namespaces\IndicesNamespace as OriginalIndicesNamespace;
+
+/**
+ * Class IndicesNamespace
+ */
+class IndicesNamespace extends OriginalIndicesNamespace {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function create(array $params = []) {
+    // If "settings" and "mapping" are not provided, assume the body contains
+    // the settings.
+    if (!empty($params['body'])) {
+      if (!isset($params['body']['settings']) && !isset($params['body']['mapping'])) {
+        @trigger_error('Index settings should be included in "settings" element.', E_USER_DEPRECATED);
+
+        $params['body'] = [
+          'settings' => $params['body'],
+        ];
+      }
+    }
+
+    return parent::create($params);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function putMapping(array $params = []) {
+    if (isset($params['type'])) {
+      @trigger_error('Field "type" should not be defined in field mapping.', E_USER_DEPRECATED);
+
+      unset($params['type']);
+    }
+
+    return parent::putMapping($params);
+  }
+
+}

--- a/src/Client/Version_7/Namespaces/IndicesNamespace.php
+++ b/src/Client/Version_7/Namespaces/IndicesNamespace.php
@@ -17,8 +17,6 @@ class IndicesNamespace extends OriginalIndicesNamespace {
     // the settings.
     if (!empty($params['body'])) {
       if (!isset($params['body']['settings']) && !isset($params['body']['mapping'])) {
-        @trigger_error('Index settings should be included in "settings" element.', E_USER_DEPRECATED);
-
         $params['body'] = [
           'settings' => $params['body'],
         ];
@@ -33,8 +31,6 @@ class IndicesNamespace extends OriginalIndicesNamespace {
    */
   public function putMapping(array $params = []) {
     if (isset($params['type'])) {
-      @trigger_error('Field "type" should not be defined in field mapping.', E_USER_DEPRECATED);
-
       unset($params['type']);
     }
 

--- a/src/ElasticsearchClientBuilder.php
+++ b/src/ElasticsearchClientBuilder.php
@@ -78,4 +78,22 @@ class ElasticsearchClientBuilder {
     return [$host];
   }
 
+  /**
+   * Returns Elasticsearch client class name based on provided version.
+   *
+   * @return string|null
+   */
+  public static function getElasticsearchClientClassName() {
+    $major_version = ElasticsearchClientVersion::getMajorVersion();
+
+    if ($major_version >= 7) {
+      return '\Drupal\elasticsearch_helper\Client\Version_7\Client';
+    }
+    elseif ($major_version >= 5) {
+      return '\Elasticsearch\Client';
+    }
+
+    return NULL;
+  }
+
 }

--- a/src/ElasticsearchClientBuilder.php
+++ b/src/ElasticsearchClientBuilder.php
@@ -4,7 +4,7 @@ namespace Drupal\elasticsearch_helper;
 
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Elasticsearch\ClientBuilder;
+use Drupal\elasticsearch_helper\Client\ClientBuilder;
 
 /**
  * Class ElasticsearchClientBuilder.

--- a/src/ElasticsearchClientVersion.php
+++ b/src/ElasticsearchClientVersion.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+use Elasticsearch\Client;
+
+/**
+ * Class ElasticsearchClientVersion
+ */
+class ElasticsearchClientVersion {
+
+  /**
+   * Returns Elasticsearch client version part array.
+   *
+   * @return array
+   */
+  public static function getVersionParts() {
+    preg_match('/^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?/', self::getVersion(), $matches);
+    // Remove the full match.
+    array_shift($matches);
+    // Provide default values for major, minor and patch versions.
+    $matches += [NULL, NULL, NULL];
+
+    return $matches;
+  }
+
+  /**
+   * Returns full version.
+   *
+   * @return string
+   */
+  public static function getVersion() {
+    return Client::VERSION;
+  }
+
+  /**
+   * Returns major version.
+   *
+   * @return string
+   */
+  public static function getMajorVersion() {
+    return self::getVersionParts()[0];
+  }
+
+  /**
+   * Returns minor version.
+   *
+   * @return string
+   */
+  public static function getMinorVersion() {
+    return self::getVersionParts()[1];
+  }
+
+  /**
+   * Returns patch version.
+   *
+   * @return string
+   */
+  public static function getPatchVersion() {
+    return self::getVersionParts()[2];
+  }
+
+}

--- a/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -13,4 +13,54 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  *   entityType = "node"
  * )
  */
-class SimpleNodeIndex extends ElasticsearchIndexBase {}
+class SimpleNodeIndex extends ElasticsearchIndexBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setup() {
+    $index_name = $this->getIndexName([]);
+
+    if (!$this->client->indices()->exists(['index' => $index_name])) {
+      $this->client->indices()->create([
+        'index' => $index_name,
+        'body' => [
+          'number_of_shards' => 1,
+          'number_of_replicas' => 0,
+        ],
+      ]);
+
+      $mapping = $this->getMapping();
+      $this->client->indices()->putMapping($mapping);
+    }
+  }
+
+  /**
+   * Returns field mapping.
+   *
+   * @return array
+   */
+  protected function getMapping() {
+    return [
+      'index' => $this->getIndexName([]),
+      'type' => $this->getTypeName([]),
+      'body' => [
+        'properties' => [
+          'id' => [
+            'type' => 'keyword',
+          ],
+          'uuid' => [
+            'type' => 'keyword',
+          ],
+          'title' => [
+            'type' => 'text',
+          ],
+          'status' => [
+            'type' => 'keyword',
+          ],
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
This change introduces an Elasticsearch-PHP client class override when Elasticsearch-PHP client library version >= 7.0 is used.

Elasticsearch Helper 8.x-6.x has been proven to work with Elasticsearch-PHP version 5.x and 6.x out of the box. Elasticsearch-PHP version 7.x introduces deprecation messages in cases when types are provided. In order to support Elasticsearch version 6 and 7, the following client libraries are used when client is built:

  - If `\Elasticsearch\Client::VERSION` is `>= 5` and `< 7`, `\Elasticsearch\Client` class is used.
  - If `\Elasticsearch\Client::VERSION` is `>= 7`, `\Elasticsearch\Client` class override class is used. In cases when Elasticsearch index plugins use legacy parameters originally used for Elasticsearch 6 (e.g., `type`), they are modified by the override client class to make them compliant with Elasticsearch 7 request syntax.

`ElasticsearchClientVersion` class is added which allows you to use the following methods:
- `ElasticsearchClientVersion::getVersion()` to get the full version (e.g., `7.6.2`)
- `ElasticsearchClientVersion::getMajorVersion()` to get the major version (e.g., `7`)
- `ElasticsearchClientVersion::getMinorVersion()`to get the minor version (e.g., `6`)
- `ElasticsearchClientVersion::getPatchVersion()` to get the patch version (e.g., `2` or `NULL` if patch version is not specified).

All existing Elasticsearch index plugins should continue to work without major changes.