### PR TITLE
Elasticsearch 6 and 7 compatibility layer (without client class override)

### DIFF
--- a/src/ElasticsearchClientVersion.php
+++ b/src/ElasticsearchClientVersion.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+use Elasticsearch\Client;
+
+/**
+ * Class ElasticsearchClientVersion
+ */
+class ElasticsearchClientVersion {
+
+  /**
+   * Returns Elasticsearch client version part array.
+   *
+   * @return array
+   */
+  public static function getVersionParts() {
+    preg_match('/^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?/', self::getVersion(), $matches);
+    // Remove the full match.
+    array_shift($matches);
+    // Provide default values for major, minor and patch versions.
+    $matches += [NULL, NULL, NULL];
+
+    return $matches;
+  }
+
+  /**
+   * Returns full version.
+   *
+   * @return string
+   */
+  public static function getVersion() {
+    return Client::VERSION;
+  }
+
+  /**
+   * Returns major version.
+   *
+   * @return string
+   */
+  public static function getMajorVersion() {
+    return self::getVersionParts()[0];
+  }
+
+  /**
+   * Returns minor version.
+   *
+   * @return string
+   */
+  public static function getMinorVersion() {
+    return self::getVersionParts()[1];
+  }
+
+  /**
+   * Returns patch version.
+   *
+   * @return string
+   */
+  public static function getPatchVersion() {
+    return self::getVersionParts()[2];
+  }
+
+}

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -100,7 +100,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   protected function prepareRequestParams($method, array &$params) {
     if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
       if (isset($params['type'])) {
-        unset($params);
+        unset($params['type']);
       }
     }
   }

--- a/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -13,4 +13,54 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  *   entityType = "node"
  * )
  */
-class SimpleNodeIndex extends ElasticsearchIndexBase {}
+class SimpleNodeIndex extends ElasticsearchIndexBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setup() {
+    $index_name = $this->getIndexName([]);
+
+    if (!$this->client->indices()->exists(['index' => $index_name])) {
+      $this->client->indices()->create([
+        'index' => $index_name,
+        'body' => [
+          'number_of_shards' => 1,
+          'number_of_replicas' => 0,
+        ],
+      ]);
+
+      $mapping = $this->getMapping();
+      $this->client->indices()->putMapping($mapping);
+    }
+  }
+
+  /**
+   * Returns field mapping.
+   *
+   * @return array
+   */
+  protected function getMapping() {
+    return [
+      'index' => $this->getIndexName([]),
+      'type' => $this->getTypeName([]),
+      'body' => [
+        'properties' => [
+          'id' => [
+            'type' => 'keyword',
+          ],
+          'uuid' => [
+            'type' => 'keyword',
+          ],
+          'title' => [
+            'type' => 'text',
+          ],
+          'status' => [
+            'type' => 'keyword',
+          ],
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
This change is similar to https://github.com/wunderio/elasticsearch_helper/pull/35 but does not override the Elasticsearch client library class.

Instead, parameter `type` is removed from requests if Elasticsearch client library version is `>= 7`.

This change allows Elasticsearch index plugins to work with Elasticsearch 7 but does not provide a drop-in support for legacy Elasticsearch index plugins made for Elasticsearch 6.

The tests fails with Elasticsearch 7 because `type` parameter cannot be removed automatically if explicitly defined in the field mapping.