### PR TITLE
Event emission is added to most common Elasticsearch operations; compatibility with Elasticsearch 7

### DIFF
--- a/elasticsearch_helper.services.yml
+++ b/elasticsearch_helper.services.yml
@@ -10,3 +10,8 @@ services:
   plugin.manager.elasticsearch_index.processor:
     class: Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@entity_type.manager', '@queue', '@logger.factory']
+
+  elasticsearch_helper.type_event_subscriber:
+    class: Drupal\elasticsearch_helper\EventSubscriber\TypeEventSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/src/ElasticsearchClientVersion.php
+++ b/src/ElasticsearchClientVersion.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+use Elasticsearch\Client;
+
+/**
+ * Class ElasticsearchClientVersion
+ */
+class ElasticsearchClientVersion {
+
+  /**
+   * Returns Elasticsearch client version part array.
+   *
+   * @return array
+   */
+  public static function getVersionParts() {
+    preg_match('/^(?:(\d+)\.)?(?:(\d+)\.)?(?:(\d+)\.)?/', self::getVersion(), $matches);
+    // Remove the full match.
+    array_shift($matches);
+    // Provide default values for major, minor and patch versions.
+    $matches += [NULL, NULL, NULL];
+
+    return $matches;
+  }
+
+  /**
+   * Returns full version.
+   *
+   * @return string
+   */
+  public static function getVersion() {
+    return Client::VERSION;
+  }
+
+  /**
+   * Returns major version.
+   *
+   * @return string
+   */
+  public static function getMajorVersion() {
+    return self::getVersionParts()[0];
+  }
+
+  /**
+   * Returns minor version.
+   *
+   * @return string
+   */
+  public static function getMinorVersion() {
+    return self::getVersionParts()[1];
+  }
+
+  /**
+   * Returns patch version.
+   *
+   * @return string
+   */
+  public static function getPatchVersion() {
+    return self::getVersionParts()[2];
+  }
+
+}

--- a/src/Event/ElasticsearchEvents.php
+++ b/src/Event/ElasticsearchEvents.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+/**
+ * Class ElasticsearchEvents
+ */
+class ElasticsearchEvents {
+
+  /**
+   * Name of the event fired when Elasticsearch operation method is called
+   * (e.g., index, update, delete).
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const OPERATION = 'elasticsearch_helper.operation';
+
+  /**
+   * Name of the event fired when Elasticsearch operation is about to be
+   * handed to Elasticsearch client.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const OPERATION_REQUEST = 'elasticsearch_helper.operation_request';
+
+}

--- a/src/Event/ElasticsearchOperationEvent.php
+++ b/src/Event/ElasticsearchOperationEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class ElasticsearchOperationEvent
+ */
+class ElasticsearchOperationEvent extends Event {
+
+  /**
+   * Elasticsearch operation.
+   *
+   * @var string
+   */
+  protected $operation;
+
+  /**
+   * Index-able object.
+   *
+   * @var mixed
+   */
+  protected $object;
+
+  /**
+   * ElasticsearchOperationEvent constructor.
+   *
+   * @param $operation
+   * @param $object
+   */
+  public function __construct($operation, $object) {
+    $this->operation = $operation;
+    $this->object = $object;
+  }
+
+  /**
+   * Returns Elasticsearch operation.
+   *
+   * @return string
+   */
+  public function &getOperation() {
+    return $this->operation;
+  }
+
+  /**
+   * Returns index-able object.
+   *
+   * @return mixed
+   */
+  public function &getObject() {
+    return $this->object;
+  }
+
+}

--- a/src/Event/ElasticsearchOperationEvent.php
+++ b/src/Event/ElasticsearchOperationEvent.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper\Event;
 
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -24,14 +25,23 @@ class ElasticsearchOperationEvent extends Event {
   protected $object;
 
   /**
+   * Elasticsearch index plugin instance.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  protected $pluginInstance;
+
+  /**
    * ElasticsearchOperationEvent constructor.
    *
    * @param $operation
    * @param $object
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
    */
-  public function __construct($operation, $object) {
+  public function __construct($operation, $object, ElasticsearchIndexInterface $plugin_instance) {
     $this->operation = $operation;
     $this->object = $object;
+    $this->pluginInstance = $plugin_instance;
   }
 
   /**
@@ -50,6 +60,15 @@ class ElasticsearchOperationEvent extends Event {
    */
   public function &getObject() {
     return $this->object;
+  }
+
+  /**
+   * Returns Elasticsearch index plugin instance.
+   *
+   * @return \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  public function getPluginInstance() {
+    return $this->pluginInstance;
   }
 
 }

--- a/src/Event/ElasticsearchOperationRequestEvent.php
+++ b/src/Event/ElasticsearchOperationRequestEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class ElasticsearchOperationRequestEvent
+ */
+class ElasticsearchOperationRequestEvent extends Event {
+
+  /**
+   * Elasticsearch operation request callable.
+   *
+   * @var callable
+   */
+  protected $callable;
+
+  /**
+   * Elasticsearch operation request callable parameters.
+   *
+   * @var array
+   */
+  protected $callableParameters = [];
+
+  /**
+   * Elasticsearch operation event.
+   *
+   * @var \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null
+   */
+  protected $operationEvent;
+
+  /**
+   * ElasticsearchOperationRequestEvent constructor.
+   *
+   * @param callable $callable
+   * @param array $callable_parameters
+   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null $operation_event
+   */
+  public function __construct($callable, array $callable_parameters, ElasticsearchOperationEvent $operation_event = NULL) {
+    $this->callable = $callable;
+    $this->callableParameters = $callable_parameters;
+    $this->operationEvent = $operation_event;
+  }
+
+  /**
+   * Returns request callable.
+   *
+   * @return callable
+   */
+  public function &getCallable() {
+    return $this->callable;
+  }
+
+  /**
+   * Returns request callable parameters.
+   *
+   * @return array
+   */
+  public function &getCallableParameters() {
+    return $this->callableParameters;
+  }
+
+  /**
+   * Returns Elasticsearch operation event.
+   *
+   * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null
+   */
+  public function &getOperationEvent() {
+    return $this->operationEvent;
+  }
+
+}

--- a/src/Event/ElasticsearchOperationRequestEvent.php
+++ b/src/Event/ElasticsearchOperationRequestEvent.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper\Event;
 
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -24,23 +25,32 @@ class ElasticsearchOperationRequestEvent extends Event {
   protected $callbackParameters = [];
 
   /**
-   * Elasticsearch operation event.
+   * Elasticsearch operation.
    *
-   * @var \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null
+   * @var string
    */
-  protected $operationEvent;
+  protected $operation;
+
+  /**
+   * Elasticsearch index plugin instance.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  protected $pluginInstance;
 
   /**
    * ElasticsearchOperationRequestEvent constructor.
    *
-   * @param callable $callback
+   * @param $callback
    * @param array $callback_parameters
-   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null $operation_event
+   * @param $operation
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
    */
-  public function __construct($callback, array $callback_parameters, ElasticsearchOperationEvent $operation_event = NULL) {
+  public function __construct($callback, array $callback_parameters, $operation, ElasticsearchIndexInterface $plugin_instance) {
     $this->callback = $callback;
     $this->callbackParameters = $callback_parameters;
-    $this->operationEvent = $operation_event;
+    $this->operation = $operation;
+    $this->pluginInstance = $plugin_instance;
   }
 
   /**
@@ -62,12 +72,21 @@ class ElasticsearchOperationRequestEvent extends Event {
   }
 
   /**
-   * Returns Elasticsearch operation event.
+   * Returns Elasticsearch operation.
    *
-   * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null
+   * @return string
    */
-  public function &getOperationEvent() {
-    return $this->operationEvent;
+  public function &getOperation() {
+    return $this->operation;
+  }
+
+  /**
+   * Returns Elasticsearch index plugin instance.
+   *
+   * @return \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  public function getPluginInstance() {
+    return $this->pluginInstance;
   }
 
 }

--- a/src/Event/ElasticsearchOperationRequestEvent.php
+++ b/src/Event/ElasticsearchOperationRequestEvent.php
@@ -14,14 +14,14 @@ class ElasticsearchOperationRequestEvent extends Event {
    *
    * @var callable
    */
-  protected $callable;
+  protected $callback;
 
   /**
    * Elasticsearch operation request callable parameters.
    *
    * @var array
    */
-  protected $callableParameters = [];
+  protected $callbackParameters = [];
 
   /**
    * Elasticsearch operation event.
@@ -33,32 +33,32 @@ class ElasticsearchOperationRequestEvent extends Event {
   /**
    * ElasticsearchOperationRequestEvent constructor.
    *
-   * @param callable $callable
-   * @param array $callable_parameters
+   * @param callable $callback
+   * @param array $callback_parameters
    * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent|null $operation_event
    */
-  public function __construct($callable, array $callable_parameters, ElasticsearchOperationEvent $operation_event = NULL) {
-    $this->callable = $callable;
-    $this->callableParameters = $callable_parameters;
+  public function __construct($callback, array $callback_parameters, ElasticsearchOperationEvent $operation_event = NULL) {
+    $this->callback = $callback;
+    $this->callbackParameters = $callback_parameters;
     $this->operationEvent = $operation_event;
   }
 
   /**
-   * Returns request callable.
+   * Returns request callback.
    *
    * @return callable
    */
-  public function &getCallable() {
-    return $this->callable;
+  public function &getCallback() {
+    return $this->callback;
   }
 
   /**
-   * Returns request callable parameters.
+   * Returns request callback parameters.
    *
    * @return array
    */
-  public function &getCallableParameters() {
-    return $this->callableParameters;
+  public function &getCallbackParameters() {
+    return $this->callbackParameters;
   }
 
   /**

--- a/src/EventSubscriber/TypeEventSubscriber.php
+++ b/src/EventSubscriber/TypeEventSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\EventSubscriber;
+
+use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
+use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
+use Drupal\elasticsearch_helper\Event\ElasticsearchOperationRequestEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class TypeEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [];
+    $events[ElasticsearchEvents::OPERATION_REQUEST][] = ['onOperationRequest'];
+
+    return $events;
+  }
+
+  /**
+   * Removes "type" parameter from the request if Elasticsearch server is >= 7.
+   *
+   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationRequestEvent $event
+   */
+  public function onOperationRequest(ElasticsearchOperationRequestEvent $event) {
+    if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
+      $callable_parameters = &$event->getCallableParameters();
+
+      if (isset($callable_parameters[0]['type'])) {
+        unset($callable_parameters[0]['type']);
+      }
+    }
+  }
+
+}

--- a/src/EventSubscriber/TypeEventSubscriber.php
+++ b/src/EventSubscriber/TypeEventSubscriber.php
@@ -26,10 +26,10 @@ class TypeEventSubscriber implements EventSubscriberInterface {
    */
   public function onOperationRequest(ElasticsearchOperationRequestEvent $event) {
     if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
-      $callable_parameters = &$event->getCallableParameters();
+      $callback_parameters = &$event->getCallbackParameters();
 
-      if (isset($callable_parameters[0]['type'])) {
-        unset($callable_parameters[0]['type']);
+      if (isset($callback_parameters[0]['type'])) {
+        unset($callback_parameters[0]['type']);
       }
     }
   }

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -180,7 +180,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'index'], [$params], $operation_event);
       $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-      return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+      return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
     }
 
     return NULL;
@@ -207,7 +207,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'get'], [$params], $operation_event);
       $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-      return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+      return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
     }
 
     return NULL;
@@ -242,7 +242,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'update'], [$params], $operation_event);
       $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-      return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+      return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
     }
 
     return NULL;
@@ -270,7 +270,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
         $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'delete'], [$params], $operation_event);
         $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-        return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+        return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
       }
       catch (Missing404Exception $e) {
         $this->logger->notice('Could not delete entry with id @id from Elasticsearh index', [
@@ -294,7 +294,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'search'], [$params]);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-    return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+    return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
   }
 
   /**
@@ -309,7 +309,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'msearch'], [$params]);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-    return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+    return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
   }
 
   /**
@@ -321,7 +321,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     $operation_event = new ElasticsearchOperationEvent($method, $body);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION, $operation_event);
 
-    if ($source = $operation_event->getObject()) {
+    if ($body = $operation_event->getObject()) {
       $serialized_data = $this->serialize($body, ['method' => $method]);
 
       $params = [
@@ -333,7 +333,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $request_event = new ElasticsearchOperationRequestEvent([$this->client, 'bulk'], [$params], $operation_event);
       $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
-      return call_user_func_array($request_event->getCallable(), $request_event->getCallableParameters());
+      return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
     }
 
     return NULL;

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -21,6 +21,8 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    *
    * @param array $source
    *   The data to be indexed.
+   *
+   * @return array|null
    */
   public function index($source);
 
@@ -29,6 +31,8 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    *
    * @param array $source
    *   The data to get.
+   *
+   * @return array|null
    */
   public function get($source);
 
@@ -37,6 +41,8 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    *
    * @param array $source
    *   The data to be used to determine which entry should be deleted.
+   *
+   * @return array|null
    */
   public function delete($source);
 
@@ -61,6 +67,8 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    * Wrapper around the Elasticsearch search() method.
    *
    * @param array $params
+   *
+   * @return array|null
    */
   public function search($params);
 
@@ -68,6 +76,8 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    * Wrapper around the Elasticsearch msearch() method.
    *
    * @param array $params
+   *
+   * @return array|null
    */
   public function msearch($params);
 
@@ -76,6 +86,8 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    *
    * @param array $body
    *   The body of the bulk operation.
+   *
+   * @return array|null
    */
   public function bulk($body);
 


### PR DESCRIPTION
Ensures compatibility with Elasticsearch 7 using events system.

This change introduces event emission from the most used methods in `ElasticsearchIndexBase` (`index()`, `get()`, `delete()`, `search()`, `msearch()`, `bulk()`):
- An event `ElasticsearchEvents::OPERATION` is emitted right after the method is called, allowing event subscribers to decide if an object needs to be operated on (indexed or deleted).
- An event `ElasticsearchEvents::OPERATION_REQUEST` is emitted right before request is sent to Elasticsearch, allowing event subscribers to make changes to callback or callback parameters.

For Elasticsearch 7 compatibility an event subscriber `TypeEventSubscriber` is added which listens to `ElasticsearchEvents::OPERATION_REQUEST` event and removes the `type` parameter from the request.

`ElasticsearchClientVersion` class is added which allows you to use the following methods:
- `ElasticsearchClientVersion::getVersion()` to get the full version (e.g., `7.6.2`)
- `ElasticsearchClientVersion::getMajorVersion()` to get the major version (e.g., `7`)
- `ElasticsearchClientVersion::getMinorVersion()`to get the minor version (e.g., `6`)
- `ElasticsearchClientVersion::getPatchVersion()` to get the patch version (e.g., `2` or `NULL` if patch version is not specified).

This change does not break existing functionality of Elasticsearch index plugins.