### PR TITLE
Updated elasticsearch_helper_example to be Drupal 9 compatible

### DIFF
--- a/examples/elasticsearch_helper_example/elasticsearch_helper_example.info.yml
+++ b/examples/elasticsearch_helper_example/elasticsearch_helper_example.info.yml
@@ -1,7 +1,7 @@
 name: Elasticsearch Helper Example
 type: module
 description: Example plugin implementation for the Elasticsearch Helper module.
-core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 hidden: true
 dependencies:
 - elasticsearch_helper

--- a/examples/elasticsearch_helper_example/elasticsearch_helper_example.services.yml
+++ b/examples/elasticsearch_helper_example/elasticsearch_helper_example.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\elasticsearch_helper_example\Plugin\Normalizer\NodeNormalizer
     tags:
       - { name: normalizer, priority: 50 }
-    arguments: ['@entity.manager']
+    arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager']

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -110,8 +110,10 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
         $this->client->indices()->create([
           'index' => 'multilingual-' . $langcode,
           'body' => [
-            'number_of_shards' => 1,
-            'number_of_replicas' => 0,
+            'settings' => [
+              'number_of_shards' => 1,
+              'number_of_replicas' => 0,
+            ],
           ],
         ]);
 

--- a/examples/elasticsearch_helper_example/src/Plugin/Normalizer/NodeNormalizer.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/Normalizer/NodeNormalizer.php
@@ -35,8 +35,8 @@ class NodeNormalizer extends ContentEntityNormalizer {
       'title' => $object->getTitle(),
       'status' => $object->isPublished(),
       'user' => [
-        'name' => $object->getRevisionAuthor()->getAccountName(),
-        'id' => $object->getRevisionAuthor()->id(),
+        'name' => $object->getRevisionUser()->getAccountName(),
+        'id' => $object->getRevisionUser()->id(),
       ],
     ];
 


### PR DESCRIPTION
It seems that elasticsearch_helper_example was not included in Drupal 9 readiness PR and thus, this PR updates elasticsearch_helper_example in examples folder to be Drupal 9 compatible.