### PR TITLE
Method rename; default document type name is defined as constanst

### DIFF
--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -116,7 +116,7 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
       $analyzer = ElasticsearchLanguageAnalyzer::get($langcode);
 
       // Put analyzer parameter to all "text" fields in the mapping.
-      foreach ($index_definition->getMappings()->getProperties() as $property) {
+      foreach ($index_definition->getMappingDefinition()->getProperties() as $property) {
         if ($property->getDataType()->getType() == 'text') {
           $property->addOption('analyzer', $analyzer);
         }
@@ -143,8 +143,8 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
     $mappings = $this->getMappingDefinition();
 
     return IndexDefinition::create()
-      ->setSettings($settings)
-      ->setMappings($mappings);
+      ->setSettingsDefinition($settings)
+      ->setMappingDefinition($mappings);
   }
 
   /**

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -39,12 +39,12 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
    * @param \Elasticsearch\Client $client
    * @param \Symfony\Component\Serializer\Serializer $serializer
    * @param \Psr\Log\LoggerInterface $logger
-   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Client $client, Serializer $serializer, LoggerInterface $logger, LanguageManagerInterface $languageManager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, Client $client, Serializer $serializer, LoggerInterface $logger, LanguageManagerInterface $language_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $client, $serializer, $logger);
 
-    $this->language_manager = $languageManager;
+    $this->language_manager = $language_manager;
   }
 
   /**

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -34,8 +34,8 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
       ]);
 
     $index_definition = IndexDefinition::create()
-      ->setMappings($mappings)
-      ->setSettings($settings);
+      ->setMappingDefinition($mappings)
+      ->setSettingsDefinition($settings);
 
     // If you are using Elasticsearch < 7, add the type to the index definition.
     $index_definition->setType($this->getTypeName([]));

--- a/src/Elasticsearch/Index/IndexDefinition.php
+++ b/src/Elasticsearch/Index/IndexDefinition.php
@@ -28,8 +28,8 @@ use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
  *   an index.
  *
  *     $index_definition = IndexDefinition::create()
- *       ->setMappings($mappings)
- *       ->setSettings($settings);
+ *       ->setMappingDefinition($mappings)
+ *       ->setSettingsDefinition($settings);
  *
  *   If Elasticsearch index plugin returns index definition in
  *   $plugin->getIndexDefinition() method, method $plugin->setup() will be
@@ -44,61 +44,61 @@ class IndexDefinition extends DefinitionBase {
   use TypeTrait;
 
   /**
-   * Index mappings.
+   * Index mapping definition.
    *
    * @var \Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition
    */
-  protected $mappings;
+  protected $mappingDefinition;
 
   /**
-   * Index settings.
+   * Index settings definition.
    *
    * @var \Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition
    */
-  protected $settings;
+  protected $settingsDefinition;
 
   /**
-   * Sets mappings definition.
+   * Sets mapping definition.
    *
-   * @param \Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition $mappings
+   * @param \Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition $mapping_definition
    *
    * @return self
    */
-  public function setMappings(MappingDefinition $mappings) {
-    $this->mappings = $mappings;
+  public function setMappingDefinition(MappingDefinition $mapping_definition) {
+    $this->mappingDefinition = $mapping_definition;
 
     return $this;
   }
 
   /**
-   * Returns mappings definition instance.
+   * Returns mapping definition instance.
    *
    * @return \Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition
    */
-  public function getMappings() {
-    return $this->mappings;
+  public function getMappingDefinition() {
+    return $this->mappingDefinition;
   }
 
   /**
-   * Sets index settings.
+   * Sets index settings definition.
    *
-   * @param \Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition $settings
+   * @param \Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition $settings_definition
    *
    * @return self
    */
-  public function setSettings(SettingsDefinition $settings) {
-    $this->settings = $settings;
+  public function setSettingsDefinition(SettingsDefinition $settings_definition) {
+    $this->settingsDefinition = $settings_definition;
 
     return $this;
   }
 
   /**
-   * Returns index settings.
+   * Returns index settings definition instance.
    *
    * @return \Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition
    */
-  public function getSettings() {
-    return $this->settings;
+  public function getSettingsDefinition() {
+    return $this->settingsDefinition;
   }
 
   /**
@@ -109,11 +109,11 @@ class IndexDefinition extends DefinitionBase {
   public function toArray() {
     $result = $this->getOptions();
 
-    if ($settings = $this->getSettings()) {
+    if ($settings = $this->getSettingsDefinition()) {
       $result['settings'] = $settings->toArray();
     }
 
-    if ($mappings = $this->getMappings()) {
+    if ($mappings = $this->getMappingDefinition()) {
       $mappings_array = $mappings->toArray();
 
       if (ElasticsearchClientVersion::getMajorVersion() < 7) {

--- a/src/Elasticsearch/Index/TypeTrait.php
+++ b/src/Elasticsearch/Index/TypeTrait.php
@@ -2,18 +2,20 @@
 
 namespace Drupal\elasticsearch_helper\Elasticsearch\Index;
 
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
+
 /**
  * Provides support for legacy "type" parameter.
  *
- * @deprecated Will be removed from the codebase when support for Elasticsearch
- *   is dropped.
+ * @deprecated Will be removed from the codebase when support for
+ *   Elasticsearch 6 is removed.
  */
 trait TypeTrait {
 
   /**
    * @var string
    */
-  protected $type = '_doc';
+  protected $type = ElasticsearchIndexInterface::TYPE_DEFAULT;
 
   /**
    * Sets index type.

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -10,6 +10,14 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 interface ElasticsearchIndexInterface extends PluginInspectionInterface {
 
   /**
+   * Defines default document type.
+   *
+   * @deprecated Will be removed from the codebase when support for
+   *   Elasticsearch 6 is removed.
+   */
+  const TYPE_DEFAULT = '_doc';
+
+  /**
    * Get the Elasticsearch client.
    *
    * @return \Drupal\elasticsearch_helper\ElasticsearchClientBuilder

--- a/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -34,8 +34,8 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
       ]);
 
     return IndexDefinition::create()
-      ->setMappings($mappings)
-      ->setSettings($settings);
+      ->setMappingDefinition($mappings)
+      ->setSettingsDefinition($settings);
   }
 
   /**


### PR DESCRIPTION
This is a technical type of change:

- Method `IndexDefinition:: setSettings()` is renamed to `IndexDefinition:: setSettingsDefinition()`
- Method `IndexDefinition:: getSettings()` is renamed to `IndexDefinition:: getSettingsDefinition()`
- Method `IndexDefinition:: setMappings()` is renamed to `IndexDefinition:: setMappingDefinition()`
- Method `IndexDefinition:: getMappings()` is renamed to `IndexDefinition:: getMappingDefinition()`
- Default document type `_doc` is defined in `ElasticsearchIndexInterface` as constant `TYPE_DEFAULT`.