### PR TITLE
Mapping context is added to methods providing index and mapping definitions

### DIFF
--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -134,13 +134,13 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getIndexDefinition() {
+  public function getIndexDefinition(array $context = []) {
     $settings = SettingsDefinition::create()
       ->addOptions([
         'number_of_shards' => 1,
         'number_of_replicas' => 0,
       ]);
-    $mappings = $this->getMappingDefinition();
+    $mappings = $this->getMappingDefinition($context);
 
     return IndexDefinition::create()
       ->setSettingsDefinition($settings)
@@ -150,7 +150,7 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getMappingDefinition() {
+  public function getMappingDefinition(array $context = []) {
     // Define only one field. Other fields will be created dynamically.
     return MappingDefinition::create()
       ->addProperty('title', FieldDefinition::create('text'));

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -22,9 +22,9 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getIndexDefinition() {
+  public function getIndexDefinition(array $context = []) {
     // Get field mappings.
-    $mappings = $this->getMappingDefinition();
+    $mappings = $this->getMappingDefinition($context);
 
     // Get index settings.
     $settings = SettingsDefinition::create()
@@ -46,7 +46,7 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getMappingDefinition() {
+  public function getMappingDefinition(array $context = []) {
     $user_property = FieldDefinition::create('object')
       ->addProperty('uid', FieldDefinition::create('integer'))
       ->addProperty('name', FieldDefinition::create('keyword'));

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -52,7 +52,7 @@ class TimeBasedIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getMappingDefinition() {
+  public function getMappingDefinition(array $context = []) {
     // Define created field.
     $created_field = FieldDefinition::create('date')
       ->addOption('format', 'epoch_second');

--- a/src/Elasticsearch/Index/MappingDefinition.php
+++ b/src/Elasticsearch/Index/MappingDefinition.php
@@ -76,6 +76,17 @@ class MappingDefinition extends DefinitionBase {
   }
 
   /**
+   * Returns a property.
+   *
+   * @param $property
+   *
+   * @return \Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition|null
+   */
+  public function getProperty($property) {
+    return isset($this->properties[$property]) ? $this->properties[$property] : NULL;
+  }
+
+  /**
    * Returns properties.
    *
    * @return \Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition[]

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -125,7 +125,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   /**
    * {@inheritdoc}
    */
-  public function getIndexDefinition() {
+  public function getIndexDefinition(array $context = []) {
   }
 
   /**

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -62,16 +62,22 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
   /**
    * Returns index definition.
    *
+   * @param array $context
+   *   Additional context parameters.
+   *
    * @return \Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition|null
    */
-  public function getIndexDefinition();
+  public function getIndexDefinition(array $context = []);
 
   /**
    * Returns index mapping definition.
    *
+   * @param array $context
+   *   Additional context parameters.
+   *
    * @return \Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition|null
    */
-  public function getMappingDefinition();
+  public function getMappingDefinition(array $context = []);
 
   /**
    * Get an array of index names for this plugin.

--- a/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -22,9 +22,9 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getIndexDefinition() {
+  public function getIndexDefinition(array $context = []) {
     // Get field mappings.
-    $mappings = $this->getMappingDefinition();
+    $mappings = $this->getMappingDefinition($context);
 
     // Get index settings.
     $settings = SettingsDefinition::create()
@@ -41,7 +41,7 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getMappingDefinition() {
+  public function getMappingDefinition(array $context = []) {
     $keyword_field = FieldDefinition::create('keyword');
 
     return MappingDefinition::create()


### PR DESCRIPTION
This change introduces `array $context = []` parameter in the following methods:
- `ElasticsearchIndexInterface::getIndexDefinition(array $context = [])`
- `ElasticsearchIndexInterface::getMappingDefinition($array $context = [])`.

This allows passing contextual parameters from `setup()` to provide the context of the index. For example, if index needs to have a custom analyzer, `setup()` method can include a `langcode` in $context to allow `getIndexDefinition()` method to indicate that index definition with support for particular language is needed.

Example:

```
/**
   * {@inheritdoc}
   */
  public function setup() {
    try {
      foreach ($this->getIndexNames() as $langcode => $index_name) {
        // Only setup index if it's not already existing.
        if (!$this->client->indices()->exists(['index' => $index_name])) {
          $context = ['langcode' => $langcode];

          // Get index definition.
          $index_definition = $this->getIndexDefinition($context);

          // Get index name.
          $index_name = $this->getIndexName(['langcode' => $langcode]);

          $this->client->indices()->create([
            'index' => $index_name,
            'body' => $index_definition->toArray(),
          ]);
        }
      }
    }
    catch (\Exception $e) {
      watchdog_exception('elasticsearch_helper_content', $e);
    }
  }

/**
   * {@inheritdoc}
   */
  public function getIndexDefinition(array $context = []) {
    $settings = $this->getIndexSettingsDefinition($context);
    
    // Add custom language analyzer based on $context['langcode'].

    $mappings = $this->getMappingDefinition($context);

    $index_definition = IndexDefinition::create()
      ->setSettingsDefinition($settings)
      ->setMappingDefinition($mappings);

    return $index_definition;
  }
```