### PR TITLE
Swedish language code fixed

### DIFF
--- a/src/ElasticsearchLanguageAnalyzer.php
+++ b/src/ElasticsearchLanguageAnalyzer.php
@@ -66,10 +66,10 @@ class ElasticsearchLanguageAnalyzer {
       'ja' => 'cjk',
       'ko' => 'cjk',
 
-      // For improved chinese support install the analysis-smartcn
-      // elasticsearch plugin with the 'smartcn' analyzer.
-      // For improved japanese support install the analysis-kuromoji
-      // elasticsearch plugin with the 'kuromoji' analyzer.
+      // For improved Chinese support install the analysis-smartcn
+      // Elasticsearch plugin with the 'smartcn' analyzer.
+      // For improved Japanese support install the analysis-kuromoji
+      // Elasticsearch plugin with the 'kuromoji' analyzer.
     ];
 
     if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
@@ -79,9 +79,8 @@ class ElasticsearchLanguageAnalyzer {
     if (isset($language_analyzers[$langcode])) {
       return $language_analyzers[$langcode];
     }
-    else {
-      return self::DEFAULT_ANALYZER;
-    }
+
+    return self::DEFAULT_ANALYZER;
   }
 
 }

--- a/src/ElasticsearchLanguageAnalyzer.php
+++ b/src/ElasticsearchLanguageAnalyzer.php
@@ -4,10 +4,13 @@ namespace Drupal\elasticsearch_helper;
 
 /**
  * Class ElasticsearchLanguageAnalyzer.
- *
- * @package Drupal\elasticsearch_helper
  */
 class ElasticsearchLanguageAnalyzer {
+
+  /**
+   * Defines default analyzer.
+   */
+  const DEFAULT_ANALYZER = 'standard';
 
   /**
    * Get the name of a language analyzer for a given language code.
@@ -21,6 +24,8 @@ class ElasticsearchLanguageAnalyzer {
   public static function get($langcode) {
     // Map language codes to the built-in language analysers documented here:
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html
+    // Standard list of languages can be found in
+    // \Drupal\Core\Language\LanguageManager::getStandardLanguageList().
     $language_analyzers = [
       'ar' => 'arabic',
       'hy' => 'armenian',
@@ -52,7 +57,7 @@ class ElasticsearchLanguageAnalyzer {
       'ru' => 'russian',
       'ku' => 'sorani',
       'es' => 'spanish',
-      'se' => 'swedish',
+      'sv' => 'swedish',
       'tr' => 'turkish',
       'th' => 'thai',
 
@@ -67,11 +72,15 @@ class ElasticsearchLanguageAnalyzer {
       // elasticsearch plugin with the 'kuromoji' analyzer.
     ];
 
+    if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
+      $language_analyzers['et'] = 'estonian';
+    }
+
     if (isset($language_analyzers[$langcode])) {
       return $language_analyzers[$langcode];
     }
     else {
-      return 'standard';
+      return self::DEFAULT_ANALYZER;
     }
   }
 


### PR DESCRIPTION
- Swedish language code fixed from `se` to `sv` (as per [ISO 639-1](https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?iso_639_1=sv)).
- Constant that defines default analyzer is added (`DEFAULT_ANALYZER`).
- Estonian language analyzer is added (if Elasticsearch >= 7).