### PR TITLE
Event\ElasticsearchOperations class added which defines common operations

### DIFF
--- a/src/Event/ElasticsearchOperations.php
+++ b/src/Event/ElasticsearchOperations.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+/**
+ * Class ElasticsearchOperations
+ */
+class ElasticsearchOperations {
+
+  /**
+   * Defines document index operation.
+   */
+  const DOCUMENT_INDEX = 'document.index';
+
+  /**
+   * Defines document retrieval operation.
+   */
+  const DOCUMENT_GET = 'document.get';
+
+  /**
+   * Defines document update operation.
+   */
+  const DOCUMENT_UPDATE = 'document.update';
+
+  /**
+   * Defines document upsert operation.
+   */
+  const DOCUMENT_UPSERT = 'document.upsert';
+
+  /**
+   * Defines document removal operation.
+   */
+  const DOCUMENT_DELETE = 'document.delete';
+
+  /**
+   * Defines document bulk-insert operation.
+   */
+  const DOCUMENT_BULK = 'document.bulk';
+
+  /**
+   * Defines index creation operation.
+   */
+  const INDEX_CREATE = 'index.create';
+
+  /**
+   * Defines index retrieval operation.
+   */
+  const INDEX_GET = 'index.get';
+
+  /**
+   * Defines index removal operation.
+   */
+  const INDEX_DROP = 'index.drop';
+
+  /**
+   * Defines query search operation.
+   */
+  const QUERY_SEARCH = 'query.search';
+
+  /**
+   * Defines query multi-search operation.
+   */
+  const QUERY_MULTI_SEARCH = 'query.msearch';
+
+}


### PR DESCRIPTION
`ElasticsearchOperations` defines the following Elasticsearch operations which are used in Elasticsearch related events:

Document related operations:
```
const DOCUMENT_INDEX = 'document.index';
const DOCUMENT_GET = 'document.get';
const DOCUMENT_UPDATE = 'document.update';
const DOCUMENT_UPSERT = 'document.upsert';
const DOCUMENT_DELETE = 'document.delete';
const DOCUMENT_BULK = 'document.bulk';
```

Index related operations:
```
const INDEX_CREATE = 'index.create';
const INDEX_GET = 'index.get';
const INDEX_DROP = 'index.drop';
```

Query related operations:
```
const QUERY_SEARCH = 'query.search';
const QUERY_MULTI_SEARCH = 'query.msearch';
```

This gives a strict reference to operations that are performed.