### PR TITLE
Indices are automatically created

### DIFF
--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -4,9 +4,7 @@ namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
 
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
-use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
-use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
 use Drupal\elasticsearch_helper\ElasticsearchLanguageAnalyzer;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
 use Elasticsearch\Client;
@@ -135,16 +133,21 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
    * {@inheritdoc}
    */
   public function getIndexDefinition(array $context = []) {
-    $settings = SettingsDefinition::create()
-      ->addOptions([
-        'number_of_shards' => 1,
-        'number_of_replicas' => 0,
-      ]);
-    $mappings = $this->getMappingDefinition($context);
+    // Get index definition.
+    $index_definition = parent::getIndexDefinition($context);
 
-    return IndexDefinition::create()
-      ->setSettingsDefinition($settings)
-      ->setMappingDefinition($mappings);
+    // Add custom settings.
+    $index_definition->getSettingsDefinition()->addOptions([
+      'analysis' => [
+        'analyzer' => [
+          'english' => [
+            'tokenizer' => 'standard',
+          ],
+        ],
+      ],
+    ]);
+
+    return $index_definition;
   }
 
   /**

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -22,30 +22,6 @@ class SimpleNodeIndex extends ElasticsearchIndexBase {
   /**
    * {@inheritdoc}
    */
-  public function getIndexDefinition(array $context = []) {
-    // Get field mappings.
-    $mappings = $this->getMappingDefinition($context);
-
-    // Get index settings.
-    $settings = SettingsDefinition::create()
-      ->addOptions([
-        'number_of_shards' => 1,
-        'number_of_replicas' => 0,
-      ]);
-
-    $index_definition = IndexDefinition::create()
-      ->setMappingDefinition($mappings)
-      ->setSettingsDefinition($settings);
-
-    // If you are using Elasticsearch < 7, add the type to the index definition.
-    $index_definition->setType($this->getTypeName([]));
-
-    return $index_definition;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getMappingDefinition(array $context = []) {
     $user_property = FieldDefinition::create('object')
       ->addProperty('uid', FieldDefinition::create('integer'))

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -7,6 +7,8 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
+use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
 use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationRequestEvent;
@@ -134,6 +136,21 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * {@inheritdoc}
    */
   public function getIndexDefinition(array $context = []) {
+    $settings_definition = SettingsDefinition::create()
+      ->addOptions([
+        'number_of_shards' => 1,
+        'number_of_replicas' => 0,
+      ]);
+    $mapping_definition = $this->getMappingDefinition($context);
+
+    $index_definition = IndexDefinition::create()
+      ->setSettingsDefinition($settings_definition)
+      ->setMappingDefinition($mapping_definition);
+
+    // If you are using Elasticsearch < 7, add the type to the index definition.
+    $index_definition->setType($this->getTypeName([]));
+
+    return $index_definition;
   }
 
   /**

--- a/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
+++ b/tests/modules/elasticsearch_helper_test/src/Plugin/ElasticsearchIndex/SimpleNodeIndex.php
@@ -3,9 +3,7 @@
 namespace Drupal\elasticsearch_helper_test\Plugin\ElasticsearchIndex;
 
 use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
-use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
-use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
 
 /**
@@ -18,25 +16,6 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
  * )
  */
 class SimpleNodeIndex extends ElasticsearchIndexBase {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getIndexDefinition(array $context = []) {
-    // Get field mappings.
-    $mappings = $this->getMappingDefinition($context);
-
-    // Get index settings.
-    $settings = SettingsDefinition::create()
-      ->addOptions([
-        'number_of_shards' => 1,
-        'number_of_replicas' => 0,
-      ]);
-
-    return IndexDefinition::create()
-      ->setMappingDefinition($mappings)
-      ->setSettingsDefinition($settings);
-  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
- This change does not require index plugins to define `getIndexDefinition()` or `setup()` methods.
- Index plugins can contain only `getMappingDefinition()` to work properly.

This code is enough to create an index and index the entity with appropriate normalizer.
```
/**
 * @ElasticsearchIndex(
 *   id = "simple_node_index",
 *   label = @Translation("Simple Node Index"),
 *   indexName = "simple",
 *   typeName = "node",
 *   entityType = "node"
 * )
 */
class SimpleNodeIndex extends ElasticsearchIndexBase {

  /**
   * {@inheritdoc}
   */
  public function getMappingDefinition(array $context = []) {
    $keyword_field = FieldDefinition::create('keyword');

    return MappingDefinition::create()
      ->addProperty('id', FieldDefinition::create('integer'))
      ->addProperty('uuid', $keyword_field)
      ->addProperty('title', FieldDefinition::create('text'))
      ->addProperty('status', $keyword_field);
  }

}
```
