### PR TITLE
Define the shards and replicas as class properties

### DIFF
--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -53,6 +53,20 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @var string
    */
   protected $placeholder_regex = '/{[_\-\w\d]*}/';
+  
+  /**
+   * Index shards.
+   *
+   * @var int
+   */
+  protected $shards;
+
+  /**
+   * Index replicas.
+   *
+   * @var int
+   */
+  protected $replicas;
 
   /**
    * ElasticsearchIndexBase constructor.
@@ -69,6 +83,10 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     $this->client = $client;
     $this->serializer = $serializer;
     $this->logger = $logger;
+    
+    // Set the default shards and replicas count.
+    $this->shards = 1;
+    $this->replicas = 0;
   }
 
   /**
@@ -138,8 +156,8 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   public function getIndexDefinition(array $context = []) {
     $settings_definition = SettingsDefinition::create()
       ->addOptions([
-        'number_of_shards' => 1,
-        'number_of_replicas' => 0,
+        'number_of_shards' => $this->shards,
+        'number_of_replicas' => $this->replicas,
       ]);
     $mapping_definition = $this->getMappingDefinition($context);
 

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -53,20 +53,18 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @var string
    */
   protected $placeholder_regex = '/{[_\-\w\d]*}/';
-  
-  /**
-   * Index shards.
-   *
-   * @var int
-   */
-  protected $shards;
 
   /**
-   * Index replicas.
+   * Default index settings.
    *
-   * @var int
+   * @var array
+   *
+   * @see getIndexDefinition()
    */
-  protected $replicas;
+  protected $defaultIndexSettings = [
+    'number_of_shards' => 1,
+    'number_of_replicas' => 0,
+  ];
 
   /**
    * ElasticsearchIndexBase constructor.
@@ -83,10 +81,6 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     $this->client = $client;
     $this->serializer = $serializer;
     $this->logger = $logger;
-    
-    // Set the default shards and replicas count.
-    $this->shards = 1;
-    $this->replicas = 0;
   }
 
   /**
@@ -155,10 +149,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    */
   public function getIndexDefinition(array $context = []) {
     $settings_definition = SettingsDefinition::create()
-      ->addOptions([
-        'number_of_shards' => $this->shards,
-        'number_of_replicas' => $this->replicas,
-      ]);
+      ->addOptions($this->defaultIndexSettings);
     $mapping_definition = $this->getMappingDefinition($context);
 
     $index_definition = IndexDefinition::create()


### PR DESCRIPTION
### Description

Define the shards and replicas as class properties to allow child classes to easily override the settings.