### PR TITLE
Fix notice errors filling logs

### DIFF
--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -9,6 +9,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
+use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
 use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationRequestEvent;
@@ -441,6 +442,11 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @return string
    */
   protected function getTypeName($data) {
+    // Set the default type to prevent throwing notice errors.
+    if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
+      return static::TYPE_DEFAULT;
+    }
+
     return $this->replacePlaceholders($this->pluginDefinition['typeName'], $data);
   }
 


### PR DESCRIPTION
### Description

This fixes the notice errors filling up the logs when `typeName` is not defined in the index plugin definition (since typename is not required anymore). The method `getTypeName` is called on every operation method, therefore if the typeName is not defined the logs will fill up with notices that `typeName` is an undefined index.