### PR TITLE
Return value of ElasticsearchIndexInterface::getClient() method fixed

### DIFF
--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -18,7 +18,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
   const TYPE_DEFAULT = '_doc';
 
   /**
-   * Get the Elasticsearch client.
+   * Returns the instance of Elasticsearch client.
    *
    * @return \Elasticsearch\Client
    */

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -20,7 +20,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
   /**
    * Get the Elasticsearch client.
    *
-   * @return \Drupal\elasticsearch_helper\ElasticsearchClientBuilder
+   * @return \Elasticsearch\Client
    */
   public function getClient();
 


### PR DESCRIPTION
`ElasticsearchIndexInterface::getClient()` returns and should return an instance of `\Elasticsearch\Client` rather than `\Drupal\elasticsearch_helper\ElasticsearchClientBuilder`

See:
1. https://github.com/wunderio/elasticsearch_helper/blob/8.x-7.x/src/Plugin/ElasticsearchIndexBase.php#L82
2. https://github.com/wunderio/elasticsearch_helper/blob/8.x-7.x/src/Plugin/ElasticsearchIndexBase.php#L109