### PR TITLE
Methods getIndexName() and getTypeName() are public

### DIFF
--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -218,7 +218,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function index($source) {
     $operation = ElasticsearchOperations::DOCUMENT_INDEX;
@@ -341,7 +341,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function search($params) {
     $params = [
@@ -357,7 +357,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function msearch($params) {
     $params = [
@@ -456,6 +456,8 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
   /**
    * Determine the name of the ID for the elasticsearch entry.
+   *
+   * @param array $data
    *
    * @return string
    */

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -499,7 +499,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @return string
    */
-  private function replacePlaceholders($haystack, $data) {
+  protected function replacePlaceholders($haystack, $data) {
     // Replace any placeholders with the right value.
     $matches = [];
 

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -434,7 +434,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @return string
    */
-  public function getIndexName($data) {
+  public function getIndexName(array $data = []) {
     return $this->replacePlaceholders($this->pluginDefinition['indexName'], $data);
   }
 
@@ -445,7 +445,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @return string
    */
-  public function getTypeName($data) {
+  public function getTypeName(array $data = []) {
     // Set the default type to prevent throwing notice errors.
     if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
       return static::TYPE_DEFAULT;
@@ -461,7 +461,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @return string
    */
-  public function getId($data) {
+  public function getId(array $data = []) {
     if (isset($data['id']) && (is_string($data['id']) || is_numeric($data['id']))) {
       // If there is an attribute with the key 'id', use it.
       return $data['id'];
@@ -495,11 +495,11 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * Replace any placeholders of the form {name} in the given string.
    *
    * @param $haystack
-   * @param $data
+   * @param array $data
    *
    * @return string
    */
-  protected function replacePlaceholders($haystack, $data) {
+  protected function replacePlaceholders($haystack, array $data) {
     // Replace any placeholders with the right value.
     $matches = [];
 

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -430,18 +430,22 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   /**
    * Determine the name of the index where the given data will be indexed.
    *
+   * @param array $data
+   *
    * @return string
    */
-  protected function getIndexName($data) {
+  public function getIndexName($data) {
     return $this->replacePlaceholders($this->pluginDefinition['indexName'], $data);
   }
 
   /**
    * Determine the name of the type where the given data will be indexed.
    *
+   * @param array $data
+   *
    * @return string
    */
-  protected function getTypeName($data) {
+  public function getTypeName($data) {
     // Set the default type to prevent throwing notice errors.
     if (ElasticsearchClientVersion::getMajorVersion() >= 7) {
       return static::TYPE_DEFAULT;


### PR DESCRIPTION
This change allows getting the name and the type of the the index that the index plugin provides.

Notable changes:
1. Signature of `protected function getIndexName($data)` changed to `public function getIndexName(array $data = [])`
2. Signature of `protected function getTypeName($data)` changed to `public function getTypeName(array $data = [])`
3. Signature of `protected function getId($data)` changed to `public function getId(array $data = [])`
4. Signature of `private function replacePlaceholders($haystack, $data)` changed to `protected function replacePlaceholders($haystack, array $data)`