### PR TITLE
Method reindex() is added to ElasticsearchIndexInterface

### DIFF
--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -49,6 +49,11 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   protected $eventDispatcher;
 
   /**
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
+   */
+  protected $indexPluginManager;
+
+  /**
    * The regular expression used to identify placeholders in index and type names.
    *
    * @var string
@@ -110,7 +115,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   }
 
   /**
-   * Gets the event dispatcher.
+   * Returns the event dispatcher.
    *
    * @return \Symfony\Component\EventDispatcher\EventDispatcherInterface
    */
@@ -118,7 +123,21 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     if (!$this->eventDispatcher) {
       $this->eventDispatcher = \Drupal::service('event_dispatcher');
     }
+
     return $this->eventDispatcher;
+  }
+
+  /**
+   * Returns Elasticsearch index plugin manager.
+   *
+   * @return \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
+   */
+  protected function getElasticsearchIndexPluginManager() {
+    if (!$this->indexPluginManager) {
+      $this->indexPluginManager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
+    }
+
+    return $this->indexPluginManager;
   }
 
   /**
@@ -396,6 +415,23 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
 
     return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function reindex() {
+    if (isset($this->pluginDefinition['entityType'])) {
+      $entity_type = $this->pluginDefinition['entityType'];
+      $bundle = NULL;
+
+      if (isset($this->pluginDefinition['bundle'])) {
+        $bundle = $this->pluginDefinition['bundle'];
+      }
+
+      // Re-index entities that this plugin manages.
+      $this->getElasticsearchIndexPluginManager()->reindexEntities($entity_type, $bundle);
+    }
   }
 
   /**

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -119,4 +119,13 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    */
   public function bulk($body);
 
+  /**
+   * Re-indexes all the content that the plugin manages.
+   *
+   * It is recommended to use the queue to reindex content.
+   *
+   * @return void
+   */
+  public function reindex();
+
 }

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -56,9 +56,11 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
   }
 
   /**
-   * Index an entity into any matching indices.
+   * Indexes the entity into any matching indices.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function indexEntity(EntityInterface $entity) {
     foreach ($this->getDefinitions() as $plugin) {
@@ -84,9 +86,11 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
   }
 
   /**
-   * Delete an entity from any matching indices.
+   * Deletes the entity from any matching indices.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function deleteEntity(EntityInterface $entity) {
     foreach ($this->getDefinitions() as $plugin) {
@@ -117,6 +121,7 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
    * @param array $indices
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Exception
    */
   public function reindex($indices = []) {
     foreach ($this->getDefinitions() as $definition) {

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -9,12 +9,15 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Elasticsearch\Common\Exceptions\ElasticsearchException;
 
 /**
  * Provides the Elasticsearch index plugin manager.
  */
 class ElasticsearchIndexManager extends DefaultPluginManager {
+
+  use StringTranslationTrait;
 
   /**
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -109,36 +112,51 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
   }
 
   /**
-   * Reindex elasticsearch with all entities.
+   * Re-indexes the content managed by Elasticsearch index plugins.
    *
-   * @param $indices
+   * @param array $indices
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function reindex($indices = []) {
-
-    foreach ($this->getDefinitions() as $plugin) {
-      if (empty($indices) || in_array($plugin['id'], $indices)) {
-
-        if ($plugin['entityType']) {
-          $query = $this->entityTypeManager->getStorage($plugin['entityType'])->getQuery();
-
-          $entity_type = $this->entityTypeManager->getDefinition($plugin['entityType']);
-
-          if ($plugin['bundle']) {
-            $query->condition($entity_type->getKey('bundle'), $plugin['bundle']);
-          }
-
-          $result = $query->execute();
-
-          foreach ($result as $entity_id) {
-            $this->queue->createItem([
-              'entity_type' => $entity_type->id(),
-              'entity_id' => $entity_id,
-            ]);
-          }
-          $this->logger->notice("Marked indices to be reindex on next cronrun");
-        }
+    foreach ($this->getDefinitions() as $definition) {
+      if (empty($indices) || in_array($definition['id'], $indices)) {
+        /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin */
+        $plugin = $this->createInstance($definition['id']);
+        $plugin->reindex();
       }
     }
+  }
+
+  /**
+   * Queues all entities of given entity type for re-indexing.
+   *
+   * @param string $entity_type
+   * @param string null $bundle
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function reindexEntities($entity_type, $bundle = NULL) {
+    $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
+
+    if ($bundle) {
+      $entity_type_instance = $this->entityTypeManager->getDefinition($entity_type);
+      $query->condition($entity_type_instance->getKey('bundle'), $bundle);
+    }
+
+    $result = $query->execute();
+
+    foreach ($result as $entity_id) {
+      $this->queue->createItem([
+        'entity_type' => $entity_type,
+        'entity_id' => $entity_id,
+      ]);
+    }
+
+    $t_args = ['@type' => $entity_type . ($bundle ? ':' . $bundle : '')];
+
+    $this->logger->notice($this->t('Entities of type "@type" will be indexed on the next cron run.', $t_args));
   }
 
 }


### PR DESCRIPTION
This change introduces `reindex()` method to `ElasticsearchIndexInterface`.

1. Index plugins that manage custom content (not entities) cannot react on `drush eshr` command since only entities are queued for indexing. `reindex()` method in the plugin interface unifies the way how content is reindexed in all kinds of index plugins.
2. Method `reindexEntities()` is added to `ElasticsearchIndexManager` which can be used for content reindex by index plugins that manage entities.

This is backwards compatible change. Existing entity reindex logic works as before.

Before:
1. `drush eshr`
2. `ElasticsearchIndexManager::reindex()`:
    * Loop over index plugin definitions.
    * If `entityType` is defined in plugin definition, all the entities are loaded and queued for reindex.

Now:
1. `drush eshr`
2. `ElasticsearchIndexManager::reindex()`:
    - Loop over index plugin definitions.
    - Get index plugin instance.
    - `$plugin->reindex()` is invoked.
    - If `reindex()` is not defined in the index plugin, `ElasticsearchIndexBase::reindex()` is invoked.
    - If index plugin manages entities, `ElasticsearchIndexManager::reindexEntities()` is invoked which loads all the entities and queues them for reindex.