### PR TITLE
Configuration structure changed; multi-host settings

### DIFF
--- a/config/install/elasticsearch_helper.settings.yml
+++ b/config/install/elasticsearch_helper.settings.yml
@@ -2,7 +2,7 @@ hosts:
   -
     scheme: http
     host: localhost
-    port: 9200
+    port: '9200'
     authentication:
       enabled: false
       user: ''

--- a/config/install/elasticsearch_helper.settings.yml
+++ b/config/install/elasticsearch_helper.settings.yml
@@ -1,8 +1,7 @@
-elasticsearch_helper:
-  scheme: "http"
-  host: "localhost"
-  port: 9200
-  authentication: 0
-  user: ""
-  password: ""
-  defer_indexing: false
+hosts:
+  -
+    scheme: 'http'
+    host: 'localhost'
+    port: 9200
+    authentication: { }
+defer_indexing: false

--- a/config/install/elasticsearch_helper.settings.yml
+++ b/config/install/elasticsearch_helper.settings.yml
@@ -1,7 +1,10 @@
 hosts:
   -
-    scheme: 'http'
-    host: 'localhost'
+    scheme: http
+    host: localhost
     port: 9200
-    authentication: { }
+    authentication:
+      enabled: 0
+      user: ''
+      password: ''
 defer_indexing: false

--- a/config/install/elasticsearch_helper.settings.yml
+++ b/config/install/elasticsearch_helper.settings.yml
@@ -4,7 +4,7 @@ hosts:
     host: localhost
     port: 9200
     authentication:
-      enabled: 0
+      enabled: false
       user: ''
       password: ''
 defer_indexing: false

--- a/config/schema/elasticsearch_helper.schema.yml
+++ b/config/schema/elasticsearch_helper.schema.yml
@@ -2,10 +2,9 @@ elasticsearch_helper.settings:
   type: config_object
   label: 'Elasticsearch helper config.'
   mapping:
-    elasticsearch_helper:
-      type: config_object
-      label: 'Elasticsearch helper config.'
-      mapping:
+    hosts:
+      type: sequence
+      sequence:
         scheme:
           type: string
           label: Scheme
@@ -16,14 +15,18 @@ elasticsearch_helper.settings:
           type: integer
           label: Port
         authentication:
-          type: integer
+          type: mapping
           label: Authentication
-        user:
-          type: string
-          label: User
-        password:
-          type: string
-          label: Password
-        defer_indexing:
-          type: boolean
-          label: 'Defer indexing'
+          mapping:
+            enabled:
+              type: boolean
+              label: Enabled
+            user:
+              type: string
+              label: User
+            password:
+              type: string
+              label: Password
+    defer_indexing:
+      type: boolean
+      label: 'Defer indexing'

--- a/config/schema/elasticsearch_helper.schema.yml
+++ b/config/schema/elasticsearch_helper.schema.yml
@@ -5,28 +5,31 @@ elasticsearch_helper.settings:
     hosts:
       type: sequence
       sequence:
-        scheme:
-          type: string
-          label: Scheme
-        host:
-          type: string
-          label: Host
-        port:
-          type: string
-          label: Port
-        authentication:
-          type: mapping
-          label: Authentication
-          mapping:
-            enabled:
-              type: boolean
-              label: Enabled
-            user:
-              type: string
-              label: User
-            password:
-              type: string
-              label: Password
+        type: mapping
+        label: Host
+        mapping:
+          scheme:
+            type: string
+            label: Scheme
+          host:
+            type: string
+            label: Host
+          port:
+            type: string
+            label: Port
+          authentication:
+            type: mapping
+            label: Authentication
+            mapping:
+              enabled:
+                type: boolean
+                label: Enabled
+              user:
+                type: string
+                label: User
+              password:
+                type: string
+                label: Password
     defer_indexing:
       type: boolean
       label: 'Defer indexing'

--- a/config/schema/elasticsearch_helper.schema.yml
+++ b/config/schema/elasticsearch_helper.schema.yml
@@ -19,7 +19,7 @@ elasticsearch_helper.settings:
           label: Authentication
           mapping:
             enabled:
-              type: boolean
+              type: integer
               label: Enabled
             user:
               type: string

--- a/config/schema/elasticsearch_helper.schema.yml
+++ b/config/schema/elasticsearch_helper.schema.yml
@@ -12,14 +12,14 @@ elasticsearch_helper.settings:
           type: string
           label: Host
         port:
-          type: integer
+          type: string
           label: Port
         authentication:
           type: mapping
           label: Authentication
           mapping:
             enabled:
-              type: integer
+              type: boolean
               label: Enabled
             user:
               type: string

--- a/elasticsearch_helper.install
+++ b/elasticsearch_helper.install
@@ -120,6 +120,6 @@ function elasticsearch_helper_update_8003() {
 
   // Reinstate the configuration.
   $config->set('hosts', $hosts);
-  $config->set('defer_indexing', $defer_indexing);
+  $config->set('defer_indexing', (bool) $defer_indexing);
   $config->save();
 }

--- a/elasticsearch_helper.install
+++ b/elasticsearch_helper.install
@@ -107,7 +107,7 @@ function elasticsearch_helper_update_8003() {
       'host' => $config->get('elasticsearch_helper.host'),
       'port' => $config->get('elasticsearch_helper.port'),
       'authentication' => [
-        'enabled' => (int) $config->get('elasticsearch_helper.authentication'),
+        'enabled' => (bool) $config->get('elasticsearch_helper.authentication'),
         'user' => $config->get('elasticsearch_helper.user'),
         'password' => $config->get('elasticsearch_helper.password'),
       ],

--- a/elasticsearch_helper.install
+++ b/elasticsearch_helper.install
@@ -88,7 +88,38 @@ function elasticsearch_helper_update_8001() {
  */
 function elasticsearch_helper_update_8002() {
   $config = \Drupal::service('config.factory')->getEditable('elasticsearch_helper.settings');
+
   if ($config->get('elasticsearch_helper.scheme')) {
     $config->set('elasticsearch_helper.scheme', 'http');
   }
+}
+
+/**
+ * Change module's configuration structure to allow defining multiple hosts.
+ */
+function elasticsearch_helper_update_8003() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('elasticsearch_helper.settings');
+
+  $hosts = [
+    [
+      'scheme' => $config->get('elasticsearch_helper.scheme'),
+      'host' => $config->get('elasticsearch_helper.host'),
+      'port' => $config->get('elasticsearch_helper.port'),
+      'authentication' => [
+        'enabled' => (int) $config->get('elasticsearch_helper.authentication'),
+        'user' => $config->get('elasticsearch_helper.user'),
+        'password' => $config->get('elasticsearch_helper.password'),
+      ],
+    ]
+  ];
+  $defer_indexing = $config->get('elasticsearch_helper.defer_indexing');
+
+  // Delete the configuration object altogether.
+  $config->delete();
+
+  // Reinstate the configuration.
+  $config->set('hosts', $hosts);
+  $config->set('defer_indexing', $defer_indexing);
+  $config->save();
 }

--- a/elasticsearch_helper.module
+++ b/elasticsearch_helper.module
@@ -12,7 +12,7 @@ use Drupal\Core\Entity\EntityInterface;
  */
 function elasticsearch_helper_entity_insert(EntityInterface $entity) {
   $config = \Drupal::config('elasticsearch_helper.settings');
-  if ($config->get('elasticsearch_helper.defer_indexing')) {
+  if ($config->get('defer_indexing')) {
     \Drupal::queue('elasticsearch_helper_indexing')
       ->createItem([
         'entity_type' => $entity->getEntityTypeId(),

--- a/src/ElasticsearchClientBuilder.php
+++ b/src/ElasticsearchClientBuilder.php
@@ -52,30 +52,27 @@ class ElasticsearchClientBuilder {
    * Get the hosts based on the site configuration.
    */
   protected function getHosts() {
-    $host = implode(':', [
-      $this->config->get('elasticsearch_helper.host'),
-      $this->config->get('elasticsearch_helper.port'),
-    ]);
+    $hosts = [];
 
-    if ($this->config->get('elasticsearch_helper.user')) {
-      $credentials = implode(':', [
-        $this->config->get('elasticsearch_helper.user'),
-        $this->config->get('elasticsearch_helper.password'),
-      ]);
+    foreach ($this->config->get('hosts') as $host_config) {
+      $host = ElasticsearchHost::createFromArray($host_config);
 
-      if (!empty($credentials)) {
-        $host = implode('@', [$credentials, $host]);
+      $host_entry = [
+        'host' => $host->getHost(),
+        'port' => $host->getPort(),
+        'scheme' => $host->getScheme(),
+      ];
+
+      if ($host->isAuthEnabled()) {
+        $host_entry['user'] = $host->getAuthUsername();
+        $host_entry['pass'] = $host->getAuthPassword();
       }
+
+      // Use only explicitly defined configuration.
+      $hosts[] = array_filter($host_entry);
     }
 
-    if ($scheme = $this->config->get('elasticsearch_helper.scheme')) {
-      $host = implode('://', [
-        $scheme,
-        $host,
-      ]);
-    }
-
-    return [$host];
+    return $hosts;
   }
 
 }

--- a/src/ElasticsearchHost.php
+++ b/src/ElasticsearchHost.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+/**
+ * Class ElasticsearchHost
+ */
+class ElasticsearchHost {
+
+  /**
+   * @var string
+   */
+  protected $scheme;
+
+  /**
+   * @var string
+   */
+  protected $host;
+
+  /**
+   * @var string
+   */
+  protected $port;
+
+  /**
+   * @var int
+   */
+  protected $authEnabled;
+
+  /**
+   * @var string
+   */
+  protected $authUsername;
+
+  /**
+   * @var string
+   */
+  protected $authPassword;
+
+  /**
+   * ElasticsearchHost constructor.
+   *
+   * @param $scheme
+   * @param $host
+   * @param $port
+   * @param $auth_enabled
+   * @param $auth_username
+   * @param $auth_password
+   */
+  public function __construct($scheme, $host, $port, $auth_enabled, $auth_username, $auth_password) {
+    $this->scheme = $scheme;
+    $this->host = $host;
+    $this->port = $port;
+    $this->authEnabled = $auth_enabled;
+    $this->authUsername = $auth_username;
+    $this->authPassword = $auth_password;
+  }
+
+  /**
+   * Creates new host instance from configuration.
+   *
+   * @param array $values
+   *
+   * @return static
+   */
+  public static function createFromArray(array $values) {
+    return new static(
+      isset($values['scheme']) ? $values['scheme'] : NULL,
+      isset($values['host']) ? $values['host'] : NULL,
+      isset($values['port']) ? $values['port'] : NULL,
+      isset($values['authentication']['enabled']) ? $values['authentication']['enabled'] : NULL,
+      isset($values['authentication']['user']) ? $values['authentication']['user'] : NULL,
+      isset($values['authentication']['password']) ? $values['authentication']['password'] : NULL
+    );
+  }
+
+  /**
+   * Returns scheme.
+   *
+   * @return string
+   */
+  public function getScheme() {
+    return $this->scheme;
+  }
+
+  /**
+   * Returns hostname.
+   *
+   * @return string
+   */
+  public function getHost() {
+    return $this->host;
+  }
+
+  /**
+   * Returns port.
+   *
+   * @return string
+   */
+  public function getPort() {
+    return $this->port;
+  }
+
+  /**
+   * Returns 1 if authentication is enabled.
+   *
+   * @return int
+   */
+  public function isAuthEnabled() {
+    return $this->authEnabled;
+  }
+
+  /**
+   * Returns authentication username.
+   *
+   * @return string
+   */
+  public function getAuthUsername() {
+    return $this->authUsername;
+  }
+
+  /**
+   * Returns authentication username.
+   *
+   * @return string
+   */
+  public function getAuthPassword() {
+    return $this->authPassword;
+  }
+
+}

--- a/src/ElasticsearchHost.php
+++ b/src/ElasticsearchHost.php
@@ -28,7 +28,7 @@ class ElasticsearchHost {
   protected $port;
 
   /**
-   * @var int
+   * @var bool
    */
   protected $authEnabled;
 
@@ -45,12 +45,12 @@ class ElasticsearchHost {
   /**
    * ElasticsearchHost constructor.
    *
-   * @param $scheme
-   * @param $host
-   * @param $port
-   * @param $auth_enabled
-   * @param $auth_username
-   * @param $auth_password
+   * @param string $scheme
+   * @param string $host
+   * @param string $port
+   * @param bool $auth_enabled
+   * @param string $auth_username
+   * @param string $auth_password
    */
   public function __construct($scheme, $host, $port, $auth_enabled, $auth_username, $auth_password) {
     $this->scheme = $scheme;
@@ -73,7 +73,7 @@ class ElasticsearchHost {
       isset($values['scheme']) ? $values['scheme'] : NULL,
       isset($values['host']) ? $values['host'] : NULL,
       isset($values['port']) ? $values['port'] : NULL,
-      isset($values['authentication']['enabled']) ? $values['authentication']['enabled'] : NULL,
+      isset($values['authentication']['enabled']) ? (bool) $values['authentication']['enabled'] : NULL,
       isset($values['authentication']['user']) ? $values['authentication']['user'] : NULL,
       isset($values['authentication']['password']) ? $values['authentication']['password'] : NULL
     );
@@ -109,7 +109,7 @@ class ElasticsearchHost {
   /**
    * Returns 1 if authentication is enabled.
    *
-   * @return int
+   * @return bool
    */
   public function isAuthEnabled() {
     return $this->authEnabled;

--- a/src/ElasticsearchHost.php
+++ b/src/ElasticsearchHost.php
@@ -8,6 +8,11 @@ namespace Drupal\elasticsearch_helper;
 class ElasticsearchHost {
 
   /**
+   * Defines default Elasticsearch server port.
+   */
+  const PORT_DEFAULT = 9200;
+
+  /**
    * @var string
    */
   protected $scheme;

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -356,7 +356,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
     // Reset host keys.
     $hosts = array_values($form_state->get('hosts'));
     $this->config->set('hosts', $hosts);
-    $this->config->set('defer_indexing', $form_state->getValue('defer_indexing'));
+    $this->config->set('defer_indexing', (bool) $form_state->getValue('defer_indexing'));
 
     // Save submitted configuration values.
     $this->config->save();

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -334,7 +334,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
         'host' => $host['host'],
         'port' => $host['port'],
         'authentication' => [
-          'enabled' => $host['authentication']['enabled'],
+          'enabled' => (bool) $host['authentication']['enabled'],
           'user' => $host['authentication']['user'],
           'password' => $host['authentication']['password'],
         ],

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -188,6 +188,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
         '#type' => 'textfield',
         '#title' => $this->t('Port'),
         '#maxlength' => 4,
+        '#placeholder' => ElasticsearchHost::PORT_DEFAULT,
         '#size' => 4,
         '#default_value' => $host->getPort(),
       ];

--- a/tests/src/FunctionalJavascript/EntityOpsTest.php
+++ b/tests/src/FunctionalJavascript/EntityOpsTest.php
@@ -29,7 +29,7 @@ class EntityOpsTest extends WebDriverTestBase {
     $this->assertEquals($queue->numberOfItems(), 0);
     \Drupal::configFactory()
       ->getEditable('elasticsearch_helper.settings')
-      ->set('defer_indexing', 1)
+      ->set('defer_indexing', TRUE)
       ->save();
     elasticsearch_helper_entity_insert($entity);
     $this->assertEquals($queue->numberOfItems(), 1);

--- a/tests/src/FunctionalJavascript/EntityOpsTest.php
+++ b/tests/src/FunctionalJavascript/EntityOpsTest.php
@@ -29,7 +29,7 @@ class EntityOpsTest extends WebDriverTestBase {
     $this->assertEquals($queue->numberOfItems(), 0);
     \Drupal::configFactory()
       ->getEditable('elasticsearch_helper.settings')
-      ->set('elasticsearch_helper.defer_indexing', 1)
+      ->set('defer_indexing', 1)
       ->save();
     elasticsearch_helper_entity_insert($entity);
     $this->assertEquals($queue->numberOfItems(), 1);

--- a/tests/src/Kernel/IndexMappingTest.php
+++ b/tests/src/Kernel/IndexMappingTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\elasticsearch_helper\Kernel;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
 use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
+use Drupal\elasticsearch_helper\ElasticsearchHost;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -69,14 +70,15 @@ class IndexMappingTest extends EntityKernelTestBase {
    * Test index mapping.
    */
   public function testIndexMapping() {
-    $elasticsearch_host = $this
+    $host = $this
       ->config('elasticsearch_helper.settings')
-      ->get('elasticsearch_helper.host');
+      ->get('hosts')[0];
+    $host = ElasticsearchHost::createFromArray($host);
 
     $index_name = 'node_index';
 
     // Query URI for fetching the document from elasticsearch.
-    $uri = 'http://' . $elasticsearch_host . ':9200/'. $index_name .'/_mapping';
+    $uri = 'http://' . $host->getHost() . ':9200/'. $index_name .'/_mapping';
 
     $response = $this->httpRequest($uri);
 

--- a/tests/src/Kernel/IndexTest.php
+++ b/tests/src/Kernel/IndexTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\elasticsearch_helper\Kernel;
 
 use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
+use Drupal\elasticsearch_helper\ElasticsearchHost;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -102,12 +103,13 @@ class IndexTest extends EntityKernelTestBase {
    *   The response.
    */
   protected function queryIndex($docId) {
-    $elasticsearch_host = $this
+    $host = $this
       ->config('elasticsearch_helper.settings')
-      ->get('elasticsearch_helper.host');
+      ->get('hosts')[0];
+    $host = ElasticsearchHost::createFromArray($host);
 
     // Query URI for fetching the document from elasticsearch.
-    $uri = 'http://' . $elasticsearch_host . ':9200/simple/_search?q=id:' . $docId;
+    $uri = 'http://' . $host->getHost() . ':9200/simple/_search?q=id:' . $docId;
     return $this->httpRequest($uri);
   }
 

--- a/tests/src/Kernel/QueueWorkerTest.php
+++ b/tests/src/Kernel/QueueWorkerTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\elasticsearch_helper\Kernel;
 
+use Drupal\elasticsearch_helper\ElasticsearchHost;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
@@ -104,12 +105,13 @@ class QueueWorkerTest extends KernelTestBase {
    *   The index count.
    */
   protected function queryIndexCount() {
-    $elasticsearch_host = $this
+    $host = $this
       ->config('elasticsearch_helper.settings')
-      ->get('elasticsearch_helper.host');
+      ->get('hosts')[0];
+    $host = ElasticsearchHost::createFromArray($host);
 
     // Query URI for fetching the document from elasticsearch.
-    $uri = 'http://' . $elasticsearch_host . ':9200/simple/_count';
+    $uri = 'http://' . $host->getHost() . ':9200/simple/_count';
 
     // Query index total count.
     // Use Curl for now because http client middleware fails in KernelTests

--- a/tests/src/Kernel/QueueWorkerTest.php
+++ b/tests/src/Kernel/QueueWorkerTest.php
@@ -53,7 +53,7 @@ class QueueWorkerTest extends KernelTestBase {
     // Enable defer indexing.
     \Drupal::configFactory()
       ->getEditable('elasticsearch_helper.settings')
-      ->set('elasticsearch_helper.defer_indexing', 1)
+      ->set('defer_indexing', 1)
       ->save();
 
     // Return elasticsearch_helper related queue and queue worker.

--- a/tests/src/Kernel/QueueWorkerTest.php
+++ b/tests/src/Kernel/QueueWorkerTest.php
@@ -53,7 +53,7 @@ class QueueWorkerTest extends KernelTestBase {
     // Enable defer indexing.
     \Drupal::configFactory()
       ->getEditable('elasticsearch_helper.settings')
-      ->set('defer_indexing', 1)
+      ->set('defer_indexing', TRUE)
       ->save();
 
     // Return elasticsearch_helper related queue and queue worker.


### PR DESCRIPTION
* Multiple hosts can be defined in settings form.
* Host configuration is dispatched to Elasticsearch in extended form (in array), rather than in a concatenated `scheme://user:pass@host:port` form (see [docs](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/configuration.html#_extended_host_configuration) for reasoning).
* Configuration structure changed for brevity.

Before:
```
elasticsearch_helper:
  scheme: http
  host: localhost
  port: 9200
  authentication: 0
  user: ''
  password: ''
  defer_indexing: false
```

After:
```
hosts:
  -
    scheme: http
    host: localhost
    port: '9200'
    authentication:
      enabled: true
      user: ''
      password: ''
defer_indexing: false
```

Please hote, that `port` value is a string and `authentication.enabled` is boolean.

Steps to review:
1. Run `lando drush updb -y` to update the configuration.
2. Run `lando drush cex -y` to export the configuration.
3. Go to http://foli.lndo.site/en/admin/config/search/elasticsearch_helper and see that you can define multiple hosts.