### PR TITLE
Upgrade instructions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,9 +26,9 @@ already defined in `getMappingDefinition()` and `getIndexDefinition()` methods.
 In Elasticsearch Helper 5.x and 6.x index plugins usually defined field mappings in `setup()`
 method as arrays.
 
-In Elasticsearch Helper 7.x `ElasticsearchIndexInterface` requires `public function getMappingDefinition()` method to
-be present in all implementation classes. This method should return an instance of `MappindDefinition`
-class which contains index field mappings described in an object oriented way.
+In Elasticsearch Helper 7.x `ElasticsearchIndexInterface` requires `public function getMappingDefinition()`
+method to be present in all implementation classes. This method should return an instance of
+`MappindDefinition` class which contains index field mappings described in an object oriented way.
 
 Each field can be described with an instance of `FieldDefinition` class. It has the following methods:
 * Nested fields can be added using `addProperty()` or `addProperties()` methods.
@@ -62,8 +62,8 @@ Example:
 Additionally, in Elasticsearch Helper 5.x and 6.x index plugins usually defined index settings in `setup()`
 method.
 
-In Elasticsearch Helper 7.x method `public function getIndexDefinition()` has been added to `ElasticsearchIndexInterface`
-to make it easier to configure the index settings.
+In Elasticsearch Helper 7.x method `public function getIndexDefinition()` has been added to
+`ElasticsearchIndexInterface` to make it easier to configure the index settings.
 
 Example:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,13 @@
+# Upgrade guide
+
+This guild is intended to describe the process of upgrading
+Elasticsearch Helper from version 5.x or 6.x to version 7.x.
+
+The most notable changes in version 7.x:
+
+1. Compatibility with Elasticsearch 6 and 7.
+2. Multi-host configuration for use in cluster environment.
+3. Support for event subscribers to react to most common Elasticsearch operations.
+4. Support for object-oriented description of index settings and field mappings.
+5. Simplified index plugin structure (no need to explicitly create index in `setup()` method).
+5. Index plugins can define their own overall content reindex procedures in `reindex()` method.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,3 +11,48 @@ The most notable changes in version 7.x:
 4. Support for object-oriented description of index settings and field mappings.
 5. Simplified index plugin structure (no need to explicitly create index in `setup()` method).
 5. Index plugins can define their own overall content reindex procedures in `reindex()` method.
+
+Upgrade checklist:
+1. [ ] Add `getMappingDefinition()` method to index plugins.
+2. [ ] Run `drush updb`.
+3. [ ] Export configuration for Elasticsearch Helper module.
+
+## Index plugins
+
+In Elasticsearch Helper 5.x and 6.x index plugins usually defined field mappings in `setup()`
+method as arrays.
+
+In Elasticsearch Helper 7.x `ElasticsearchIndexInterface` requires `public function getMappingDefinition()` method to
+be present in all implementation classes. This method should return an instance of `MappindDefinition`
+class which contains index field mappings described in an object oriented way.
+
+Each field can be described with an instance of `FieldDefinition` class. It has the following methods:
+* Nested fields can be added using `addProperty()` or `addProperties()` methods.
+* Multi-fields can be added using `addMultiField()` method.
+* Options can be added using `addOption()` or `addOptions()` methods.
+
+
+Example:
+
+```
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappingDefinition(array $context = []) {
+    $name_property = FieldDefinition::create('text')
+      ->addOption('analyzer', 'english')
+      ->addMultiField('keyword', FieldDefinition::create('keyword'));
+
+    $user_property = FieldDefinition::create('object')
+      ->addProperty('uid', FieldDefinition::create('integer'))
+      ->addProperty('name', $name_property);
+
+    return MappingDefinition::create()
+      ->addProperty('id', FieldDefinition::create('integer'))
+      ->addProperty('uuid', FieldDefinition::create('keyword'))
+      ->addProperty('title', FieldDefinition::create('text'))
+      ->addProperty('status', FieldDefinition::create('keyword'))
+      ->addProperty('user', $user_property);
+  }
+```
+

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrade guide
 
-This guild is intended to describe the process of upgrading
+This guide is intended to describe the process of upgrading
 Elasticsearch Helper from version 5.x or 6.x to version 7.x.
 
 The most notable changes in version 7.x:
@@ -9,15 +9,19 @@ The most notable changes in version 7.x:
 2. Multi-host configuration for use in cluster environment.
 3. Support for event subscribers to react to most common Elasticsearch operations.
 4. Support for object-oriented description of index settings and field mappings.
-5. Simplified index plugin structure (no need to explicitly create index in `setup()` method).
+5. Simplified index plugin structure (no need to explicitly create an index in `setup()` method).
 5. Index plugins can define their own overall content reindex procedures in `reindex()` method.
 
-Upgrade checklist:
-1. [ ] Add `getMappingDefinition()` method to index plugins.
-2. [ ] Run `drush updb`.
-3. [ ] Export configuration for Elasticsearch Helper module.
+Minimal upgrade checklist:
+1. [ ] Add `getMappingDefinition()` method to index plugins to conform to the interface.
+2. [ ] Revise the necessity of `setup()` method in index plugins. Fields and index settings are
+already defined in `getMappingDefinition()` and `getIndexDefinition()` methods.
+3. [ ] Run `drush updb` to update the configuration structure.
+4. [ ] Export configuration of Elasticsearch Helper module.
 
-## Index plugins
+## Changes in index plugins
+
+### New methods
 
 In Elasticsearch Helper 5.x and 6.x index plugins usually defined field mappings in `setup()`
 method as arrays.
@@ -31,7 +35,6 @@ Each field can be described with an instance of `FieldDefinition` class. It has 
 * Multi-fields can be added using `addMultiField()` method.
 * Options can be added using `addOption()` or `addOptions()` methods.
 
-
 Example:
 
 ```
@@ -39,13 +42,13 @@ Example:
    * {@inheritdoc}
    */
   public function getMappingDefinition(array $context = []) {
-    $name_property = FieldDefinition::create('text')
+    $name_field = FieldDefinition::create('text')
       ->addOption('analyzer', 'english')
       ->addMultiField('keyword', FieldDefinition::create('keyword'));
 
     $user_property = FieldDefinition::create('object')
       ->addProperty('uid', FieldDefinition::create('integer'))
-      ->addProperty('name', $name_property);
+      ->addProperty('name', $name_field);
 
     return MappingDefinition::create()
       ->addProperty('id', FieldDefinition::create('integer'))
@@ -56,3 +59,114 @@ Example:
   }
 ```
 
+Additionally, in Elasticsearch Helper 5.x and 6.x index plugins usually defined index settings in `setup()`
+method.
+
+In Elasticsearch Helper 7.x method `public function getIndexDefinition()` has been added to `ElasticsearchIndexInterface`
+to make it easier to configure the index settings.
+
+Example:
+
+```
+/**
+ * {@inheritdoc}
+ */
+public function getIndexDefinition(array $context = []) {
+// Get index definition.
+$index_definition = parent::getIndexDefinition($context);
+
+// Add custom settings.
+$index_definition->getSettingsDefinition()->addOptions([
+  'analysis' => [
+    'analyzer' => [
+      'english' => [
+        'tokenizer' => 'standard',
+      ],
+    ],
+  ],
+]);
+
+return $index_definition;
+}
+```
+
+By default, `ElasticsearchIndexBase` class provides the following
+default index settings which can be overridden in index plugins:
+
+```
+'number_of_shards' => 1,
+'number_of_replicas' => 0,
+```
+
+### Changes in existing methods
+
+Change the signature of the following methods if index plugins have them:
+
+Before (Elasticsearch Helper 5.x and 6.x):
+
+```
+protected function getIndexName($data)
+protected function getTypeName($data)
+public function getId($data)
+```
+
+After (Elasticsearch Helper 7.x):
+
+```
+public function getIndexName(array $data = [])
+public function getTypeName(array $data = [])
+public function getId(array $data = [])
+```
+
+## Changes in configuration
+
+Running `drush updb` and exporting the changed configuration should be sufficient
+to convert the configuration structure to the new format.
+
+Configuration object `elasticsearch_helper.settings` structure has been changed:
+
+Before (Elasticsearch Helper 5.x and 6.x):
+
+```
+elasticsearch_helper:
+  scheme: http
+  host: localhost
+  port: 9200
+  authentication: 0
+  user: ''
+  password: ''
+  defer_indexing: false
+```
+
+After (Elasticsearch Helper 7.x):
+
+```
+hosts:
+  -
+    scheme: http
+    host: localhost
+    port: '9200'
+    authentication:
+      enabled: true
+      user: ''
+      password: ''
+defer_indexing: false
+```
+
+### settings.php
+
+Update the settings in `settings.php` file if necessary:
+
+Before (Elasticsearch Helper 5.x and 6.x):
+
+ ```
+ $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = 'localhost';
+ $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = '9200';
+ ```
+
+After (Elasticsearch Helper 7.x):
+
+ ```
+ $config['elasticsearch_helper.settings']['hosts'][0]['host'] = 'localhost';
+ $config['elasticsearch_helper.settings']['hosts'][0]['port'] = '9200';
+ ```


### PR DESCRIPTION
This change adds `UPGRADE.md` file to facilitate the upgrade from Elasticsearch Helper 5.x and 6.x to 7.x.