### PR TITLE
Contextual parameters are added to reindex() method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,6 +40,14 @@ composer require drupal/elasticsearch_helper_views
 
 ### New methods
 
+Three new methods are added to ElasticsearchIndexInterface:
+
+1. `public function getMappingDefinition(array $context = [])`
+2. `public function getIndexDefinition(array $context = [])`
+3. `public function reindex(array $context = [])`
+
+#### getMappingDefinition()
+
 In Elasticsearch Helper 5.x and 6.x index plugins usually defined field mappings in `setup()`
 method as arrays.
 
@@ -75,6 +83,8 @@ Example:
       ->addProperty('user', $user_property);
   }
 ```
+
+#### getIndexDefinition()
 
 Additionally, in Elasticsearch Helper 5.x and 6.x index plugins usually defined index settings in `setup()`
 method.
@@ -114,6 +124,13 @@ default index settings which can be overridden in index plugins:
 'number_of_shards' => 1,
 'number_of_replicas' => 0,
 ```
+
+#### reindex()
+
+In Elasticsearch Helper 5.x and 6.x running `drush elasticsearch-helper-reindex` would only reindex entities.
+
+In Elasticsearch Helper 7.x index plugins can define their own reindex logic in `reindex()` method. Existing
+index plugins that manage entities work as before.
 
 ### Changes in existing methods
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,7 +40,7 @@ composer require drupal/elasticsearch_helper_views
 
 ### New methods
 
-Three new methods are added to ElasticsearchIndexInterface:
+Three new methods are added to `ElasticsearchIndexInterface`:
 
 1. `public function getMappingDefinition(array $context = [])`
 2. `public function getIndexDefinition(array $context = [])`
@@ -51,7 +51,7 @@ Three new methods are added to ElasticsearchIndexInterface:
 In Elasticsearch Helper 5.x and 6.x index plugins usually defined field mappings in `setup()`
 method as arrays.
 
-In Elasticsearch Helper 7.x `ElasticsearchIndexInterface` requires `public function getMappingDefinition()`
+In Elasticsearch Helper 7.x `ElasticsearchIndexInterface` requires `getMappingDefinition()`
 method to be present in all implementation classes. This method should return an instance of
 `MappindDefinition` class which contains index field mappings described in an object oriented way.
 
@@ -84,13 +84,14 @@ Example:
   }
 ```
 
+This method needs to be explicitly implemented in every index plugin.
+
 #### getIndexDefinition()
 
-Additionally, in Elasticsearch Helper 5.x and 6.x index plugins usually defined index settings in `setup()`
+In Elasticsearch Helper 5.x and 6.x index plugins usually defined index settings in `setup()`
 method.
 
-In Elasticsearch Helper 7.x method `public function getIndexDefinition()` has been added to
-`ElasticsearchIndexInterface` to make it easier to configure the index settings.
+In Elasticsearch Helper 7.x method `getIndexDefinition()` makes it easier to configure index settings.
 
 Example:
 
@@ -99,38 +100,62 @@ Example:
  * {@inheritdoc}
  */
 public function getIndexDefinition(array $context = []) {
-// Get index definition.
-$index_definition = parent::getIndexDefinition($context);
+  // Get index definition.
+  $index_definition = parent::getIndexDefinition($context);
 
-// Add custom settings.
-$index_definition->getSettingsDefinition()->addOptions([
-  'analysis' => [
-    'analyzer' => [
-      'english' => [
-        'tokenizer' => 'standard',
+  // Add custom settings.
+  $index_definition->getSettingsDefinition()->addOptions([
+    'analysis' => [
+      'analyzer' => [
+        'english' => [
+          'tokenizer' => 'standard',
+        ],
       ],
     ],
-  ],
-]);
+  ]);
 
-return $index_definition;
+  return $index_definition;
 }
 ```
 
-By default, `ElasticsearchIndexBase` class provides the following
-default index settings which can be overridden in index plugins:
+By default `ElasticsearchIndexBase::getIndexDefinition()` provides the following
+default index settings which can be overridden in `getIndexDefinition()` method in extending index plugins:
 
 ```
 'number_of_shards' => 1,
 'number_of_replicas' => 0,
 ```
 
+Example:
+
+```
+/**
+ * {@inheritdoc}
+ */
+public function getIndexDefinition(array $context = []) {
+  // Get index definition.
+  $index_definition = parent::getIndexDefinition($context);
+
+  // Add custom settings.
+  $index_definition->getSettingsDefinition()->addOptions([
+    'number_of_shards' => 2,
+    'number_of_replicas' => 1,
+  ]);
+
+  return $index_definition;
+}
+```
+
 #### reindex()
 
-In Elasticsearch Helper 5.x and 6.x running `drush elasticsearch-helper-reindex` would only reindex entities.
+In Elasticsearch Helper 5.x and 6.x running `drush elasticsearch-helper-reindex` would only affect index plugins
+that index entities of type defined in `entityType` plugin definition.
 
-In Elasticsearch Helper 7.x index plugins can define their own reindex logic in `reindex()` method. Existing
-index plugins that manage entities work as before.
+In Elasticsearch Helper 7.x index plugins can define their own reindex logic in `reindex()` method, allowing index
+plugins that manage non-entity content react when `drush elasticsearch-helper-reindex` command is run.
+
+By default `ElasticsearchIndexBase::reindex()` method re-indexes entities managed by index plugins that define entity
+type in `entityType` plugin definition.
 
 ### Changes in existing methods
 

--- a/examples/elasticsearch_helper_example/elasticsearch_helper_example.services.yml
+++ b/examples/elasticsearch_helper_example/elasticsearch_helper_example.services.yml
@@ -4,3 +4,7 @@ services:
     tags:
       - { name: normalizer, priority: 50 }
     arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager']
+  elasticsearch_helper_example.reindex_event_subscriber:
+    class: Drupal\elasticsearch_helper_example\EventSubscriber\ReindexEventSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/examples/elasticsearch_helper_example/src/EventSubscriber/ReindexEventSubscriber.php
+++ b/examples/elasticsearch_helper_example/src/EventSubscriber/ReindexEventSubscriber.php
@@ -12,6 +12,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class ReindexEventSubscriber implements EventSubscriberInterface {
 
   /**
+   * @var string
+   */
+  protected $ignoredPluginId = 'time_based_index';
+
+  /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
@@ -30,7 +35,7 @@ class ReindexEventSubscriber implements EventSubscriberInterface {
     $plugin = $event->getPluginInstance();
 
     // Change the reindex callback for "time_based_index" index plugin.
-    if ($plugin->getPluginId() == 'time_based_index') {
+    if ($plugin->getPluginId() == $this->ignoredPluginId) {
       $callback = &$event->getCallback();
       $callback = [$this, 'reindexNone'];
     }
@@ -40,7 +45,9 @@ class ReindexEventSubscriber implements EventSubscriberInterface {
    * Dummy reindex callback.
    */
   public function reindexNone() {
-    \Drupal::logger('elasticsearch_helper_example')->info(t('Content will not be re-indexed.'));
+    $t_args = ['@plugin_id' => $this->ignoredPluginId];
+    $message = t('Content will not be re-indexed for "@plugin_id" index plugin.', $t_args);
+    \Drupal::logger('elasticsearch_helper_example')->notice($message);
   }
 
 }

--- a/examples/elasticsearch_helper_example/src/EventSubscriber/ReindexEventSubscriber.php
+++ b/examples/elasticsearch_helper_example/src/EventSubscriber/ReindexEventSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_example\EventSubscriber;
+
+use Drupal\elasticsearch_helper\Event\ElasticsearchHelperEvents;
+use Drupal\elasticsearch_helper\Event\ElasticsearchHelperGenericEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class ReindexEventSubscriber
+ */
+class ReindexEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [];
+    $events[ElasticsearchHelperEvents::REINDEX][] = ['onReindex'];
+
+    return $events;
+  }
+
+  /**
+   * Replaces the callback to dummy callback.
+   *
+   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchHelperGenericEvent $event
+   */
+  public function onReindex(ElasticsearchHelperGenericEvent $event) {
+    $plugin = $event->getPluginInstance();
+
+    // Change the reindex callback for "time_based_index" index plugin.
+    if ($plugin->getPluginId() == 'time_based_index') {
+      $callback = &$event->getCallback();
+      $callback = [$this, 'reindexNone'];
+    }
+  }
+
+  /**
+   * Dummy reindex callback.
+   */
+  public function reindexNone() {
+    \Drupal::logger('elasticsearch_helper_example')->info(t('Content will not be re-indexed.'));
+  }
+
+}

--- a/src/Commands/ElasticsearchHelperCommands.php
+++ b/src/Commands/ElasticsearchHelperCommands.php
@@ -20,14 +20,14 @@ class ElasticsearchHelperCommands extends DrushCommands {
    * ElasticsearchHelperCommands constructor.
    *
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $manager
-   *   The elastic manager.
+   *   The Elasticsearch index plugin manager.
    */
   public function __construct(ElasticsearchIndexManager $manager) {
     $this->elasticsearchPluginManager = $manager;
   }
 
   /**
-   * List ElasticsearchIndex plugins.
+   * Lists Elasticsearch index plugins.
    *
    * @command elasticsearch:helper:list
    * @table-style default
@@ -52,11 +52,15 @@ class ElasticsearchHelperCommands extends DrushCommands {
   }
 
   /**
-   * Setup Elasticsearch indices.
+   * Creates Elasticsearch indices.
+   *
+   * @param string|null $indices
+   *   Comma separated list of indices to be set up
    *
    * @command elasticsearch:helper:setup
-   * @param $indices Comma separated list of indices to be set up
    * @aliases eshs,elasticsearch-helper-setup
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function helperSetup($indices = NULL) {
     // Indices can be specified with a comma-separate value.
@@ -71,11 +75,15 @@ class ElasticsearchHelperCommands extends DrushCommands {
   }
 
   /**
-   * Drop Elasticsearch indices.
+   * Drops Elasticsearch indices.
+   *
+   * @param string|null $indices
+   *   Comma separated list of indices to be deleted
    *
    * @command elasticsearch:helper:drop
-   * @param $indices Comma separated list of indices to be deleted
    * @aliases eshd,elasticsearch-helper-drop
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
    */
   public function helperDrop($indices = NULL) {
     // Indices can be specified with a comma-separate value.
@@ -110,18 +118,26 @@ class ElasticsearchHelperCommands extends DrushCommands {
   }
 
   /**
-   * Reindex entities associated with an elasticsearch index
+   * Re-indexes entities associated with an Elasticsearch index plugin.
+   *
+   * @param string|null $indices
+   *   Comma separated list of indices for which entities should be re-indexed.
    *
    * @command elasticsearch:helper:reindex
-   * @param $indices Comma separated list of indices for which entities should be reindexed
    * @aliases eshr,elasticsearch-helper-reindex
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Exception
    */
   public function helperReindex($indices = NULL) {
     // Indices can be specified with a comma-separate value.
     if ($indices && is_string($indices)) {
       $indices = explode(',', $indices);
     }
-    $this->elasticsearchPluginManager->reindex($indices);
+
+    $context['caller'] = 'drush';
+
+    $this->elasticsearchPluginManager->reindex($indices, $context);
   }
 
 }

--- a/src/Commands/ElasticsearchHelperCommands.php
+++ b/src/Commands/ElasticsearchHelperCommands.php
@@ -135,8 +135,7 @@ class ElasticsearchHelperCommands extends DrushCommands {
       $indices = explode(',', $indices);
     }
 
-    $context['caller'] = 'drush';
-
+    $context = ['caller' => 'drush'];
     $this->elasticsearchPluginManager->reindex($indices, $context);
   }
 

--- a/src/Event/ElasticsearchHelperEvents.php
+++ b/src/Event/ElasticsearchHelperEvents.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+/**
+ * Class ElasticsearchHelperEvents
+ */
+class ElasticsearchHelperEvents {
+
+  /**
+   * Name of the event fired when content is re-indexed.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const REINDEX = 'elasticsearch_helper.reindex';
+
+}

--- a/src/Event/ElasticsearchHelperGenericEvent.php
+++ b/src/Event/ElasticsearchHelperGenericEvent.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class ElasticsearchHelperGenericEvent
+ */
+class ElasticsearchHelperGenericEvent extends Event {
+
+  /**
+   * Elasticsearch operation request callable.
+   *
+   * @var callable
+   */
+  protected $callback;
+
+  /**
+   * Elasticsearch operation request callable parameters.
+   *
+   * @var array
+   */
+  protected $callbackParameters = [];
+
+  /**
+   * Elasticsearch index plugin instance.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  protected $pluginInstance;
+
+  /**
+   * ElasticsearchHelperGenericEvent constructor.
+   *
+   * @param $callback
+   * @param array $callback_parameters
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
+   */
+  public function __construct($callback, array $callback_parameters, ElasticsearchIndexInterface $plugin_instance) {
+    $this->callback = $callback;
+    $this->callbackParameters = $callback_parameters;
+    $this->pluginInstance = $plugin_instance;
+  }
+
+  /**
+   * Returns request callback.
+   *
+   * @return callable
+   */
+  public function &getCallback() {
+    return $this->callback;
+  }
+
+  /**
+   * Returns request callback parameters.
+   *
+   * @return array
+   */
+  public function &getCallbackParameters() {
+    return $this->callbackParameters;
+  }
+
+  /**
+   * Returns Elasticsearch index plugin instance.
+   *
+   * @return \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  public function getPluginInstance() {
+    return $this->pluginInstance;
+  }
+
+}

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -11,6 +11,8 @@ use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
 use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
 use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
+use Drupal\elasticsearch_helper\Event\ElasticsearchHelperEvents;
+use Drupal\elasticsearch_helper\Event\ElasticsearchHelperGenericEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationRequestEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperations;
@@ -429,14 +431,26 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
         $bundle = $this->pluginDefinition['bundle'];
       }
 
-      // Re-index entities that this plugin manages.
-      $this->getElasticsearchIndexPluginManager()->reindexEntities($entity_type, $bundle);
+      // Emit reindex event.
+      $callback = [$this->getElasticsearchIndexPluginManager(), 'reindexEntities'];
+      $params = [$entity_type, $bundle];
+      $request_event = new ElasticsearchHelperGenericEvent($callback, $params, $this);
+      $this->getEventDispatcher()->dispatch(ElasticsearchHelperEvents::REINDEX, $request_event);
+
+      return call_user_func_array($request_event->getCallback(), $request_event->getCallbackParameters());
     }
   }
 
   /**
+   * Serializes the source object.
+   *
    * Transform the data from its native format (most likely a Drupal entity) to
    * the format that should be stored in the Elasticsearch index.
+   *
+   * @param mixed $source
+   * @param array $context
+   *
+   * @return array
    */
   public function serialize($source, $context = []) {
     if ($source instanceof EntityInterface) {

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -420,7 +420,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   /**
    * {@inheritdoc}
    */
-  public function reindex() {
+  public function reindex(array $context = []) {
     if (isset($this->pluginDefinition['entityType'])) {
       $entity_type = $this->pluginDefinition['entityType'];
       $bundle = NULL;

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -127,7 +127,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    * @param array $context
    *   Additional context parameters.
    *
-   * @return void
+   * @return mixed
    */
   public function reindex(array $context = []);
 

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -124,8 +124,11 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    *
    * It is recommended to use the queue to reindex content.
    *
+   * @param array $context
+   *   Additional context parameters.
+   *
    * @return void
    */
-  public function reindex();
+  public function reindex(array $context = []);
 
 }

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -119,16 +119,17 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
    * Re-indexes the content managed by Elasticsearch index plugins.
    *
    * @param array $indices
+   * @param array $context
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    * @throws \Exception
    */
-  public function reindex($indices = []) {
+  public function reindex($indices = [], array $context = []) {
     foreach ($this->getDefinitions() as $definition) {
       if (empty($indices) || in_array($definition['id'], $indices)) {
         /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin */
         $plugin = $this->createInstance($definition['id']);
-        $plugin->reindex();
+        $plugin->reindex($context);
       }
     }
   }


### PR DESCRIPTION
1. Contextual parameters allows index plugins to reindex content differently based on given parameters.

For example, when `drush eshr` command is called, index plugins receive contextual parameters with `caller` being set to `drush`.

2. Event subscribers can change the callback which is called for content reindexing.