### PR TITLE
Typo in permission name changed ("configured elasticsearch helper")

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,17 +12,22 @@ The most notable changes in version 7.x:
 5. Simplified index plugin structure (no need to explicitly create an index in `setup()` method).
 6. Index plugins can define their own overall content reindex procedures in `reindex()` method.
 7. Sub-modules are split into their own separate projects:
-  * [Elasticsearch Helper AWS](https://drupal.org/project/elasticsearch_helper_aws)
-  * [Elasticsearch Helper Content](https://www.drupal.org/project/elasticsearch_helper_content)
-  * [Elasticsearch Helper Instant](https://www.drupal.org/project/elasticsearch_helper_instant)
-  * [Elasticsearch Helper Views](https://www.drupal.org/project/elasticsearch_helper_views)
+    * [Elasticsearch Helper AWS](https://drupal.org/project/elasticsearch_helper_aws)
+    * [Elasticsearch Helper Content](https://www.drupal.org/project/elasticsearch_helper_content)
+    * [Elasticsearch Helper Instant](https://www.drupal.org/project/elasticsearch_helper_instant)
+    * [Elasticsearch Helper Views](https://www.drupal.org/project/elasticsearch_helper_views)
+8. Typo in permission name changed (`configured elasticsearch helper => configure elasticsearch helper`).
 
 Minimal upgrade checklist:
 1. [ ] Add `getMappingDefinition()` method to index plugins to conform to the interface.
 2. [ ] Revise the necessity of `setup()` method in index plugins. Fields and index settings are
-already defined in `getMappingDefinition()` and `getIndexDefinition()` methods.
-3. [ ] Run `drush updb` to update the configuration structure.
-4. [ ] Export configuration of Elasticsearch Helper module.
+already defined in `getMappingDefinition()` and `getIndexDefinition()` methods. Consider defining
+index settings in `getIndexDefinition()` rather than in `setup()` method.
+3. [ ] Run `drush updb` to update the configuration.
+4. [ ] Run `drush cr` to clear caches (this is necessary to discover changed permission name).
+5. [ ] Run `drush cex` to export the configuration.
+6. [ ] Commit the changes in Export Elasticsearch Helper configuration and in role configuration
+with updated permission name.
 
 ## Changes in included sub-modules
 
@@ -211,6 +216,8 @@ hosts:
       password: ''
 defer_indexing: false
 ```
+
+Permission name `configured elasticsearch helper` has been changed to `configure elasticsearch helper`.
 
 ### settings.php
 

--- a/elasticsearch_helper.install
+++ b/elasticsearch_helper.install
@@ -6,6 +6,7 @@
  */
 
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Drupal\user\Entity\Role;
 
 /**
  * Implements hook_requirements.
@@ -98,6 +99,7 @@ function elasticsearch_helper_update_8002() {
  * Change module's configuration structure to allow defining multiple hosts.
  */
 function elasticsearch_helper_update_8003() {
+  // Update module configuration.
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('elasticsearch_helper.settings');
 
@@ -122,4 +124,18 @@ function elasticsearch_helper_update_8003() {
   $config->set('hosts', $hosts);
   $config->set('defer_indexing', (bool) $defer_indexing);
   $config->save();
+
+  // Update permission name.
+  $mistyped_permission = 'configured elasticsearch helper';
+  $permission = 'configure elasticsearch helper';
+
+  /** @var \Drupal\user\RoleInterface $role */
+  foreach (Role::loadMultiple() as $role) {
+    if ($role->hasPermission($mistyped_permission)) {
+      $role->revokePermission($mistyped_permission);
+      $role->grantPermission($permission);
+
+      $role->trustData()->save();
+    }
+  }
 }

--- a/elasticsearch_helper.permissions.yml
+++ b/elasticsearch_helper.permissions.yml
@@ -1,5 +1,4 @@
-
-configured elasticsearch helper:
+configure elasticsearch helper:
   title: 'Configure Elasticsearch Helper'
   description: 'Allow users to configure Elasticsearch helper module'
   restrict access: true


### PR DESCRIPTION
This change fixes the typo in Elasticsearch Helper permission name `configured elasticsearch helper => configure elasticsearch helper`.

Steps to review:
1. Run `drush updb`.
2. Run `drush cr`.
3. Run `drush cex` and commit changes in user roles.