### PR TITLE
Interface param type changed in PhpDoc annotation

### DIFF
--- a/elasticsearch_helper.module
+++ b/elasticsearch_helper.module
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityInterface;
  */
 function elasticsearch_helper_entity_insert(EntityInterface $entity) {
   $config = \Drupal::config('elasticsearch_helper.settings');
+
   if ($config->get('defer_indexing')) {
     \Drupal::queue('elasticsearch_helper_indexing')
       ->createItem([
@@ -20,7 +21,9 @@ function elasticsearch_helper_entity_insert(EntityInterface $entity) {
       ]);
   }
   else {
-    \Drupal::service('plugin.manager.elasticsearch_index.processor')->indexEntity($entity);
+    /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $index_plugin_manager */
+    $index_plugin_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
+    $index_plugin_manager->indexEntity($entity);
   }
 }
 
@@ -35,30 +38,30 @@ function elasticsearch_helper_entity_update(EntityInterface $entity) {
  * Implements hook_entity_translation_delete().
  */
 function elasticsearch_helper_entity_translation_delete(EntityInterface $entity) {
-  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $elasticsearchPluginManager */
-  \Drupal::service('plugin.manager.elasticsearch_index.processor')->deleteEntity($entity);
+  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $index_plugin_manager */
+  $index_plugin_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
+  $index_plugin_manager->deleteEntity($entity);
 }
 
 /**
  * Implements hook_entity_delete().
  */
 function elasticsearch_helper_entity_delete(EntityInterface $entity) {
-  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $elasticsearchPluginManager */
-  \Drupal::service('plugin.manager.elasticsearch_index.processor')->deleteEntity($entity);
+  elasticsearch_helper_entity_translation_delete($entity);
 }
 
 /**
  * Implements hook_modules_installed().
  */
 function elasticsearch_helper_modules_installed($modules) {
-  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $elasticsearchPluginManager */
-  $elasticsearchPluginManager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
+  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $index_plugin_manager */
+  $index_plugin_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
 
-  foreach ($elasticsearchPluginManager->getDefinitions() as $plugin) {
+  foreach ($index_plugin_manager->getDefinitions() as $plugin) {
     // If the plugin provider was just installed.
     if (in_array($plugin['provider'], $modules)) {
-      // Setup indidices for that plugin.
-      $elasticsearchPluginManager->createInstance($plugin['id'])->setup();
+      // Setup indices for that plugin.
+      $index_plugin_manager->createInstance($plugin['id'])->setup();
     }
   }
 }
@@ -67,14 +70,14 @@ function elasticsearch_helper_modules_installed($modules) {
  * Implements hook_module_preuninstall().
  */
 function elasticsearch_helper_module_preuninstall($module) {
-  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $elasticsearchPluginManager */
-  $elasticsearchPluginManager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
+  /** @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager $index_plugin_manager */
+  $index_plugin_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
 
-  foreach ($elasticsearchPluginManager->getDefinitions() as $plugin) {
+  foreach ($index_plugin_manager->getDefinitions() as $plugin) {
     // If the plugin provider is about to be uninstalled.
     if ($plugin['provider'] == $module) {
       // Drop indices for that plugin.
-      $elasticsearchPluginManager->createInstance($plugin['id'])->drop();
+      $index_plugin_manager->createInstance($plugin['id'])->drop();
     }
   }
 }

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -27,7 +27,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
   /**
    * Put data into the Elasticsearch index.
    *
-   * @param array $source
+   * @param mixed $source
    *   The data to be indexed.
    *
    * @return array|null
@@ -37,7 +37,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
   /**
    * Get record from Elasticsearch index.
    *
-   * @param array $source
+   * @param mixed $source
    *   The data to get.
    *
    * @return array|null
@@ -47,7 +47,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
   /**
    * Delete an entry from the Elasticsearch index.
    *
-   * @param array $source
+   * @param mixed $source
    *   The data to be used to determine which entry should be deleted.
    *
    * @return array|null

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -44,6 +44,12 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
    *   Cache backend instance to use.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler to invoke the alter hook with.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager instance.
+   * @param \Drupal\Core\Queue\QueueFactory $queue_factory
+   *   Queue factory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   Logger factory.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_type_manager, QueueFactory $queue_factory, LoggerChannelFactoryInterface $logger_factory) {
     parent::__construct('Plugin/ElasticsearchIndex', $namespaces, $module_handler, 'Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface', 'Drupal\elasticsearch_helper\Annotation\ElasticsearchIndex');

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -108,8 +108,6 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
           $this->logger->error('Elasticsearch deletion failed: @message', [
             '@message' => $e->getMessage(),
           ]);
-
-          // TODO: queue for later indexing.
         }
       }
     }


### PR DESCRIPTION
This change declares `mixed` type parameter for `index()`, `get()` and `delete()` method's PhpDoc annotation on Elasticsearch index plugin.

Type `array|null` caused confusion for PhpStorm as most of the time the `$source` object is an instance of `EntityInterface`.