### PR TITLE
Request param argument is cast to array

### DIFF
--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -60,7 +60,8 @@ class TimeBasedIndex extends ElasticsearchIndexBase {
         $result = $this->executeCallback($operation, $callback, $request_params);
         $this->dispatchOperationResultEvent($result, $operation, NULL, $request_params);
       }
-    } catch (\Throwable $e) {
+    }
+    catch (\Throwable $e) {
       $request_params = isset($request_params) ? $request_params : NULL;
       $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_params);
     }

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -62,7 +62,7 @@ class TimeBasedIndex extends ElasticsearchIndexBase {
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_params);
     }
   }

--- a/src/Event/ElasticsearchOperationErrorEvent.php
+++ b/src/Event/ElasticsearchOperationErrorEvent.php
@@ -22,10 +22,10 @@ class ElasticsearchOperationErrorEvent extends ElasticsearchOperationStatusEvent
    * @param \Throwable $error
    * @param $operation
    * @param $object
-   * @param $request_parameters
+   * @param array $request_parameters
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
    */
-  public function __construct(\Throwable $error, $operation, $object, $request_parameters, ElasticsearchIndexInterface $plugin_instance) {
+  public function __construct(\Throwable $error, $operation, $object, array $request_parameters, ElasticsearchIndexInterface $plugin_instance) {
     $this->error = $error;
     $this->operation = $operation;
     $this->object = $object;

--- a/src/Event/ElasticsearchOperationResultEvent.php
+++ b/src/Event/ElasticsearchOperationResultEvent.php
@@ -22,10 +22,10 @@ class ElasticsearchOperationResultEvent extends ElasticsearchOperationStatusEven
    * @param array $result
    * @param $operation
    * @param $object
-   * @param $request_parameters
+   * @param array $request_parameters
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
    */
-  public function __construct(array $result, $operation, $object, $request_parameters, ElasticsearchIndexInterface $plugin_instance) {
+  public function __construct(array $result, $operation, $object, array $request_parameters, ElasticsearchIndexInterface $plugin_instance) {
     $this->result = $result;
     $this->operation = $operation;
     $this->object = $object;

--- a/src/Event/ElasticsearchOperationStatusEventBase.php
+++ b/src/Event/ElasticsearchOperationStatusEventBase.php
@@ -26,7 +26,7 @@ abstract class ElasticsearchOperationStatusEventBase extends Event {
   /**
    * Contains request parameters.
    *
-   * @var array|null
+   * @var array
    */
   protected $requestParameters;
 
@@ -58,7 +58,7 @@ abstract class ElasticsearchOperationStatusEventBase extends Event {
   /**
    * Returns request parameters (if available).
    *
-   * @return array|null
+   * @return array
    */
   public function getRequestParameters() {
     return $this->requestParameters;

--- a/src/EventSubscriber/LoggingEventSubscriber.php
+++ b/src/EventSubscriber/LoggingEventSubscriber.php
@@ -89,7 +89,7 @@ class LoggingEventSubscriber implements EventSubscriberInterface {
       $context = $this->getIdentifiedDocumentContext($event);
       $message = $this->isIdentifiableDocument($event)
         ? 'Could not index document "@id" into "@index" Elasticsearch index.'
-        : 'Could not index document.';
+        : '@error';
 
       $this->logger->error($message, $context);
     }
@@ -97,7 +97,7 @@ class LoggingEventSubscriber implements EventSubscriberInterface {
       $context = $this->getIdentifiedDocumentContext($event);
       $message = $this->isIdentifiableDocument($event)
         ? 'Could not delete document "@id" from "@index" Elasticsearch index.'
-        : 'Could not delete document.';
+        : '@error';
 
       $this->logger->notice($message, $context);
     }

--- a/src/EventSubscriber/MessagingEventSubscriber.php
+++ b/src/EventSubscriber/MessagingEventSubscriber.php
@@ -41,7 +41,7 @@ class MessagingEventSubscriber implements EventSubscriberInterface {
       $context = $this->getIdentifiedDocumentContext($event);
       $message = $this->isIdentifiableDocument($event)
         ? 'Could not index document "@id" into "@index" Elasticsearch index.'
-        : 'Could not index document.';
+        : 'Could not index the document. Unexpected error occurred: @error';
 
       $this->messenger()->addError($this->t($message, $context));
     }

--- a/src/EventSubscriber/MessagingEventSubscriber.php
+++ b/src/EventSubscriber/MessagingEventSubscriber.php
@@ -34,6 +34,11 @@ class MessagingEventSubscriber implements EventSubscriberInterface {
    * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent $event
    */
   public function onOperationError(ElasticsearchOperationErrorEvent $event) {
+    // Do not display messages when executed in the command line.
+    if (PHP_SAPI === 'cli') {
+      return;
+    }
+
     $operation = $event->getOperation();
 
     // Customise the message for certain expected exceptions.

--- a/src/EventSubscriber/OperationStatusTrait.php
+++ b/src/EventSubscriber/OperationStatusTrait.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\elasticsearch_helper\EventSubscriber;
 
+use Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationStatusEventBase;
 
 /**
@@ -48,10 +49,16 @@ trait OperationStatusTrait {
       'id' => NULL,
     ];
 
-    return [
+    $result = [
       '@index' => $request_params['index'],
       '@id' => $request_params['id'],
     ];
+
+    if ($error = $this->getError($event)) {
+      $result['@error'] = $error->getMessage();
+    }
+
+    return $result;
   }
 
   /**
@@ -66,9 +73,30 @@ trait OperationStatusTrait {
       'index' => NULL,
     ];
 
-    return [
+    $result = [
       '@index' => $request_params['index'],
     ];
+
+    if ($error = $this->getError($event)) {
+      $result['@error'] = $error->getMessage();
+    }
+
+    return $result;
+  }
+
+  /**
+   * Returns an instance of throwable error (if available).
+   *
+   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationStatusEventBase $event
+   *
+   * @return \Throwable|null
+   */
+  protected function getError(ElasticsearchOperationStatusEventBase $event) {
+    if ($event instanceof ElasticsearchOperationErrorEvent) {
+      return $event->getError();
+    }
+
+    return NULL;
   }
 
 }

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -257,7 +257,8 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
           $this->createIndex($index_name, $index_definition);
         }
       }
-    } catch (\Throwable $e) {
+    }
+    catch (\Throwable $e) {
       $this->dispatchOperationErrorEvent($e, ElasticsearchOperations::INDEX_CREATE);
     }
   }
@@ -281,7 +282,8 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $callback = [$this->client->indices(), 'create'];
       $result = $this->executeCallback($operation, $callback, $request_params);
       $this->dispatchOperationResultEvent($result, $operation, NULL, $request_params);
-    } catch (\Throwable $e) {
+    }
+    catch (\Throwable $e) {
       $request_params = isset($request_params) ? $request_params : NULL;
       $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_params);
     }

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -203,7 +203,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationResultEvent
    */
-  protected function dispatchOperationResultEvent(array $result, $operation, $source = NULL, $request_params = []) {
+  protected function dispatchOperationResultEvent(array $result, $operation, $source = NULL, array $request_params = []) {
     $event = new ElasticsearchOperationResultEvent($result, $operation, $source, $request_params, $this);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_RESULT, $event);
 
@@ -220,7 +220,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent
    */
-  protected function dispatchOperationErrorEvent(\Throwable $error, $operation, $source = NULL, $request_params = []) {
+  protected function dispatchOperationErrorEvent(\Throwable $error, $operation, $source = NULL, array $request_params = []) {
     $event = new ElasticsearchOperationErrorEvent($error, $operation, $source, $request_params, $this);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_ERROR, $event);
 
@@ -284,7 +284,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $this->dispatchOperationResultEvent($result, $operation, NULL, $request_params);
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_params);
     }
   }
@@ -308,7 +308,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       return array_keys($result);
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_params);
 
       throw $e;
@@ -339,7 +339,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_params);
     }
   }
@@ -371,7 +371,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $source, $request_params);
     }
   }
@@ -401,7 +401,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $source, $request_params);
 
       throw $e;
@@ -437,7 +437,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $source, $request_params);
     }
   }
@@ -465,7 +465,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $source, $request_params);
     }
   }
@@ -489,7 +489,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       return $result;
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $params, $request_params);
 
       throw $e;
@@ -515,7 +515,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       return $result;
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $params, $request_params);
 
       throw $e;
@@ -545,7 +545,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       }
     }
     catch (\Throwable $e) {
-      $request_params = isset($request_params) ? $request_params : NULL;
+      $request_params = isset($request_params) ? $request_params : [];
       $this->dispatchOperationErrorEvent($e, $operation, $body, $request_params);
     }
   }


### PR DESCRIPTION
1. This change fixes the issue where request parameter variable in `ElasticsearchOperationResultEvent` and `ElasticsearchOperationErrorEvent` is supposed to be an array but sometimes was passed as `NULL` which produced an `unsupported operand types` error.

2. Error messages (in `messenger` service context) are not generated when code is executed in the command line. This stops errors from being duplicated in the console.