### PR TITLE
OperationPermissionInterface is added

### DIFF
--- a/examples/elasticsearch_helper_example/src/EventSubscriber/ReindexEventSubscriber.php
+++ b/examples/elasticsearch_helper_example/src/EventSubscriber/ReindexEventSubscriber.php
@@ -3,7 +3,7 @@
 namespace Drupal\elasticsearch_helper_example\EventSubscriber;
 
 use Drupal\elasticsearch_helper\Event\ElasticsearchHelperEvents;
-use Drupal\elasticsearch_helper\Event\ElasticsearchHelperGenericEvent;
+use Drupal\elasticsearch_helper\Event\ElasticsearchHelperCallbackEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -29,9 +29,9 @@ class ReindexEventSubscriber implements EventSubscriberInterface {
   /**
    * Replaces the callback to dummy callback.
    *
-   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchHelperGenericEvent $event
+   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchHelperCallbackEvent $event
    */
-  public function onReindex(ElasticsearchHelperGenericEvent $event) {
+  public function onReindex(ElasticsearchHelperCallbackEvent $event) {
     $plugin = $event->getPluginInstance();
 
     // Change the reindex callback for "time_based_index" index plugin.

--- a/src/Event/ElasticsearchHelperCallbackEvent.php
+++ b/src/Event/ElasticsearchHelperCallbackEvent.php
@@ -6,9 +6,14 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class ElasticsearchHelperGenericEvent
+ * Elasticsearch Helper callback event.
+ *
+ * This event should be used for Elasticsearch Helper related operations
+ * where internal callback is invoked instead of a request to Elasticsearch.
+ *
+ * @see \Drupal\elasticsearch_helper\Event\ElasticsearchOperationRequestEvent
  */
-class ElasticsearchHelperGenericEvent extends Event {
+class ElasticsearchHelperCallbackEvent extends Event {
 
   /**
    * Elasticsearch operation.
@@ -39,7 +44,7 @@ class ElasticsearchHelperGenericEvent extends Event {
   protected $pluginInstance;
 
   /**
-   * ElasticsearchHelperGenericEvent constructor.
+   * ElasticsearchHelperCallbackEvent constructor.
    *
    * @param $operation
    * @param $callback

--- a/src/Event/ElasticsearchOperationErrorEvent.php
+++ b/src/Event/ElasticsearchOperationErrorEvent.php
@@ -6,7 +6,17 @@ use Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class ElasticsearchOperationErrorEvent
+ * Elasticsearch operation error event.
+ *
+ * This event should be used when a throwable object is caught in methods
+ * defined in ElasticsearchIndexInterface.
+ *
+ * If error is caught during request to Elasticsearch, an instance of
+ * ElasticsearchRequestWrapperInterface should be present in the event. If
+ * error occurred before request wrapper object has been made (e.g., during
+ * content serialization), request wrapper object will not be available.
+ *
+ * @see \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
  */
 class ElasticsearchOperationErrorEvent extends Event {
 

--- a/src/Event/ElasticsearchOperationEvent.php
+++ b/src/Event/ElasticsearchOperationEvent.php
@@ -6,9 +6,20 @@ use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class ElasticsearchOperationEvent
+ * Elasticsearch operation event.
+ *
+ * This event should be used when Elasticsearch operation is about to be
+ * performed. It can be a general high-level operation or index/document related
+ * operation.
+ *
+ * Note: this event implements operation permission interface and event
+ * listeners may prevent operation from being allowed. Always use
+ * $event->isOperationAllowed() where event is being emitted to check if
+ * operation is allowed to proceed.
  */
-class ElasticsearchOperationEvent extends Event {
+class ElasticsearchOperationEvent extends Event implements OperationPermissionInterface {
+
+  use OperationPermissionTrait;
 
   /**
    * Elasticsearch operation.
@@ -18,13 +29,6 @@ class ElasticsearchOperationEvent extends Event {
   protected $operation;
 
   /**
-   * Index-able object.
-   *
-   * @var mixed|null
-   */
-  protected $object;
-
-  /**
    * Elasticsearch index plugin instance.
    *
    * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
@@ -32,16 +36,28 @@ class ElasticsearchOperationEvent extends Event {
   protected $pluginInstance;
 
   /**
+   * An object on which the operation is performed.
+   *
+   * For document index operation, the object is an array, an entity etc.
+   * For index create operation, the object is an index name.
+   *
+   * For general high-level operations object can be NULL.
+   *
+   * @var mixed|null
+   */
+  protected $object;
+
+  /**
    * ElasticsearchOperationEvent constructor.
    *
    * @param $operation
-   * @param mixed $object
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
+   * @param mixed|null $object
    */
-  public function __construct($operation, $object, ElasticsearchIndexInterface $plugin_instance) {
+  public function __construct($operation, ElasticsearchIndexInterface $plugin_instance, $object = NULL) {
     $this->operation = $operation;
-    $this->object = $object;
     $this->pluginInstance = $plugin_instance;
+    $this->object = $object;
   }
 
   /**
@@ -54,7 +70,7 @@ class ElasticsearchOperationEvent extends Event {
   }
 
   /**
-   * Returns index-able object.
+   * Returns the actionable object.
    *
    * @return mixed|null
    */

--- a/src/Event/ElasticsearchOperationRequestEvent.php
+++ b/src/Event/ElasticsearchOperationRequestEvent.php
@@ -6,7 +6,12 @@ use Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class ElasticsearchOperationRequestEvent
+ * Elasticsearch operation request event.
+ *
+ * This event should be used for Elasticsearch operation where request to
+ * Elasticsearch is about to be performed via callback.
+ *
+ * @see \Drupal\elasticsearch_helper\Event\ElasticsearchHelperCallbackEvent
  */
 class ElasticsearchOperationRequestEvent extends Event {
 

--- a/src/Event/ElasticsearchOperationRequestResultEvent.php
+++ b/src/Event/ElasticsearchOperationRequestResultEvent.php
@@ -6,7 +6,10 @@ use Drupal\elasticsearch_helper\ElasticsearchRequestResult;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class ElasticsearchOperationRequestResultEvent
+ * Elasticsearch operation request result event.
+ *
+ * This event should be used after resulting response is received from
+ * Elasticsearch.
  */
 class ElasticsearchOperationRequestResultEvent extends Event {
 

--- a/src/Event/OperationPermissionInterface.php
+++ b/src/Event/OperationPermissionInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\Event;
+
+/**
+ * Defines operation permission interface.
+ *
+ * Operation permission is used to indicate if operation can be performed.
+ *
+ * If should be used on events where callback is invoked.
+ */
+interface OperationPermissionInterface {
+
+  /**
+   * Return TRUE if operation is allowed to be performed.
+   *
+   * @return bool
+   */
+  public function isOperationAllowed();
+
+  /**
+   * Allow the operation to be performed.
+   */
+  public function allowOperation();
+
+  /**
+   * Disallow the operation to be performed.
+   */
+  public function forbidOperation();
+
+}

--- a/src/Event/OperationPermissionTrait.php
+++ b/src/Event/OperationPermissionTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Drupal\elasticsearch_helper\Event;
+
+/**
+ * Operation permission trait.
+ */
+trait OperationPermissionTrait {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $allowed = TRUE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isOperationAllowed() {
+    return $this->allowed;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function allowOperation() {
+    $this->allowed = TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function forbidOperation() {
+    $this->allowed = FALSE;
+  }
+
+}

--- a/src/Plugin/ElasticsearchIndexInterface.php
+++ b/src/Plugin/ElasticsearchIndexInterface.php
@@ -40,7 +40,7 @@ interface ElasticsearchIndexInterface extends PluginInspectionInterface {
    *
    * @return array
    *
-   * @throws \Exception
+   * @throws \Throwable
    */
   public function get($source);
 


### PR DESCRIPTION
This change adds `OperationPermissionInterface` to `ElasticsearchOperationEvent` which allows to check if event subscribers have allowed or disallowed the operation.

For example, before this change `index()` method emitted the `ElasticsearchOperationEvent` event and allowed other modules to unset the entity object to disable the index operation.

Now event listeners can call `$event->forbidOperation()` on event object to prevent entity from being serialized and indexed. `index()` method calls `$event->isOperationAllowed()` to determine if events have allowed or disallowed the operation.

Comments are added to event classes to describe when they should be used.