### PR TITLE
Index plugin is added to ElasticsearchOperationErrorEvent

### DIFF
--- a/src/ElasticsearchRequestResult.php
+++ b/src/ElasticsearchRequestResult.php
@@ -3,9 +3,9 @@
 namespace Drupal\elasticsearch_helper;
 
 /**
- * Class ElasticsearchRequestResult
+ * Elasticsearch request result class.
  */
-class ElasticsearchRequestResult {
+class ElasticsearchRequestResult implements ElasticsearchRequestResultInterface {
 
   /**
    * Elasticsearch request wrapper instance.
@@ -33,18 +33,14 @@ class ElasticsearchRequestResult {
   }
 
   /**
-   * Returns Elasticsearch request wrapper instance.
-   *
-   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface
+   * {@inheritdoc}
    */
   public function getRequestWrapper() {
     return $this->requestWrapper;
   }
 
   /**
-   * Returns Elasticsearch request result contents.
-   *
-   * @return mixed
+   * {@inheritdoc}
    */
   public function getResultBody() {
     return $this->resultBody;

--- a/src/ElasticsearchRequestResultInterface.php
+++ b/src/ElasticsearchRequestResultInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+/**
+ * Defines Elasticsearch request result interface.
+ */
+interface ElasticsearchRequestResultInterface {
+
+  /**
+   * Returns Elasticsearch request wrapper instance.
+   *
+   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface
+   */
+  public function getRequestWrapper();
+
+  /**
+   * Returns Elasticsearch request result contents.
+   *
+   * @return mixed
+   */
+  public function getResultBody();
+
+}

--- a/src/ElasticsearchRequestWrapper.php
+++ b/src/ElasticsearchRequestWrapper.php
@@ -126,22 +126,33 @@ class ElasticsearchRequestWrapper implements ElasticsearchRequestWrapperInterfac
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST, $request_event);
 
     // Execute the request.
-    $result = new ElasticsearchRequestResult($this, $this->executeCallback());
+    $result = $this->executeCallback();
 
     // Dispatch the result event.
-    $result_event = new ElasticsearchOperationRequestResultEvent($result);
-    $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST_RESULT, $result_event);
+    $this->dispatchRequestResultEvent($result);
 
     return $result;
   }
 
   /**
-   * Executes the callback.
+   * Executes the callback and returns an instance of request result.
    *
-   * @return mixed
+   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface
    */
   protected function executeCallback() {
-    return call_user_func_array($this->getCallback(), $this->getCallbackParameters());
+    $result = call_user_func_array($this->getCallback(), $this->getCallbackParameters());
+
+    return new ElasticsearchRequestResult($this, $result);
+  }
+
+  /**
+   * Dispatches request result event.
+   *
+   * @param \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface $result
+   */
+  protected function dispatchRequestResultEvent(ElasticsearchRequestResultInterface $result) {
+    $result_event = new ElasticsearchOperationRequestResultEvent($result);
+    $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_REQUEST_RESULT, $result_event);
   }
 
   /**

--- a/src/ElasticsearchRequestWrapperInterface.php
+++ b/src/ElasticsearchRequestWrapperInterface.php
@@ -47,7 +47,7 @@ interface ElasticsearchRequestWrapperInterface {
   /**
    * Executes the request and returns the request result instance.
    *
-   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestResult
+   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface
    *
    * @throws \Throwable
    */

--- a/src/Event/ElasticsearchOperationErrorEvent.php
+++ b/src/Event/ElasticsearchOperationErrorEvent.php
@@ -3,6 +3,7 @@
 namespace Drupal\elasticsearch_helper\Event;
 
 use Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -35,6 +36,13 @@ class ElasticsearchOperationErrorEvent extends Event {
   protected $operation;
 
   /**
+   * Elasticsearch index plugin instance.
+   *
+   * @var \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface
+   */
+  protected $pluginInstance;
+
+  /**
    * Elasticsearch request wrapper instance.
    *
    * Request wrapper instance will only be available for errors that were
@@ -49,11 +57,13 @@ class ElasticsearchOperationErrorEvent extends Event {
    *
    * @param \Throwable $error
    * @param $operation
+   * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
    * @param \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface $request_wrapper
    */
-  public function __construct(\Throwable $error, $operation, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
+  public function __construct(\Throwable $error, $operation, ElasticsearchIndexInterface $plugin_instance, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
     $this->error = $error;
     $this->operation = $operation;
+    $this->pluginInstance = $plugin_instance;
     $this->requestWrapper = $request_wrapper;
   }
 
@@ -73,6 +83,13 @@ class ElasticsearchOperationErrorEvent extends Event {
    */
   public function getOperation() {
     return $this->operation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginInstance() {
+    return $this->pluginInstance;
   }
 
   /**

--- a/src/Event/ElasticsearchOperationRequestResultEvent.php
+++ b/src/Event/ElasticsearchOperationRequestResultEvent.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\elasticsearch_helper\Event;
 
-use Drupal\elasticsearch_helper\ElasticsearchRequestResult;
+use Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -16,23 +16,23 @@ class ElasticsearchOperationRequestResultEvent extends Event {
   /**
    * Elasticsearch request result.
    *
-   * @var \Drupal\elasticsearch_helper\ElasticsearchRequestResult
+   * @var \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface
    */
   protected $requestResult;
 
   /**
    * ElasticsearchOperationRequestResultEvent constructor.
    *
-   * @param \Drupal\elasticsearch_helper\ElasticsearchRequestResult $result
+   * @param \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface $result
    */
-  public function __construct(ElasticsearchRequestResult $result) {
+  public function __construct(ElasticsearchRequestResultInterface $result) {
     $this->requestResult = $result;
   }
 
   /**
    * Returns Elasticsearch request result body.
    *
-   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestResult
+   * @return \Drupal\elasticsearch_helper\ElasticsearchRequestResultInterface
    */
   public function getResult() {
     return $this->requestResult;

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -186,7 +186,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent
    */
   protected function dispatchOperationErrorEvent(\Throwable $error, $operation, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
-    $event = new ElasticsearchOperationErrorEvent($error, $operation, $request_wrapper);
+    $event = new ElasticsearchOperationErrorEvent($error, $operation, $this, $request_wrapper);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_ERROR, $event);
 
     return $event;


### PR DESCRIPTION
This change provides event listeners the context of the index plugin in which an error occurred.

- `ElasticsearchRequestResultInterface` is added.