### PR TITLE
Indexable object is added to ElasticsearchOperationErrorEvent

### DIFF
--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -73,7 +73,7 @@ class TimeBasedIndex extends ElasticsearchIndexBase {
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
     }
   }
 

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -73,7 +73,7 @@ class TimeBasedIndex extends ElasticsearchIndexBase {
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
     }
   }
 

--- a/src/ElasticsearchRequestWrapper.php
+++ b/src/ElasticsearchRequestWrapper.php
@@ -61,7 +61,7 @@ class ElasticsearchRequestWrapper implements ElasticsearchRequestWrapperInterfac
    * @param $callback
    * @param array $callback_parameters
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
-   * @param null $object
+   * @param mixed|null $object
    */
   public function __construct(EventDispatcherInterface $event_dispatcher, $operation, $callback, array $callback_parameters, ElasticsearchIndexInterface $plugin_instance, $object = NULL) {
     $this->eventDispatcher = $event_dispatcher;

--- a/src/ElasticsearchRequestWrapperInterface.php
+++ b/src/ElasticsearchRequestWrapperInterface.php
@@ -36,9 +36,9 @@ interface ElasticsearchRequestWrapperInterface {
   public function getPluginInstance();
 
   /**
-   * Returns index-able object.
+   * Returns the actionable object.
    *
-   * Value is returned by reference as index-able object can be of any type.
+   * Value is returned by reference as actionable object can be of any type.
    *
    * @return mixed|null
    */

--- a/src/Event/ElasticsearchOperationErrorEvent.php
+++ b/src/Event/ElasticsearchOperationErrorEvent.php
@@ -43,6 +43,13 @@ class ElasticsearchOperationErrorEvent extends Event {
   protected $pluginInstance;
 
   /**
+   * Index-able object.
+   *
+   * @var mixed|null
+   */
+  protected $object;
+
+  /**
    * Elasticsearch request wrapper instance.
    *
    * Request wrapper instance will only be available for errors that were
@@ -58,12 +65,14 @@ class ElasticsearchOperationErrorEvent extends Event {
    * @param \Throwable $error
    * @param $operation
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
+   * @param mixed|null $object
    * @param \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface $request_wrapper
    */
-  public function __construct(\Throwable $error, $operation, ElasticsearchIndexInterface $plugin_instance, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
+  public function __construct(\Throwable $error, $operation, ElasticsearchIndexInterface $plugin_instance, $object = NULL, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
     $this->error = $error;
     $this->operation = $operation;
     $this->pluginInstance = $plugin_instance;
+    $this->object = $object;
     $this->requestWrapper = $request_wrapper;
   }
 
@@ -90,6 +99,13 @@ class ElasticsearchOperationErrorEvent extends Event {
    */
   public function getPluginInstance() {
     return $this->pluginInstance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function &getObject() {
+    return $this->object;
   }
 
   /**

--- a/src/Event/ElasticsearchOperationErrorEvent.php
+++ b/src/Event/ElasticsearchOperationErrorEvent.php
@@ -43,13 +43,6 @@ class ElasticsearchOperationErrorEvent extends Event {
   protected $pluginInstance;
 
   /**
-   * Index-able object.
-   *
-   * @var mixed|null
-   */
-  protected $object;
-
-  /**
    * Elasticsearch request wrapper instance.
    *
    * Request wrapper instance will only be available for errors that were
@@ -60,20 +53,27 @@ class ElasticsearchOperationErrorEvent extends Event {
   protected $requestWrapper;
 
   /**
+   * Index-able object.
+   *
+   * @var mixed|null
+   */
+  protected $object;
+
+  /**
    * ElasticsearchOperationErrorEvent constructor.
    *
    * @param \Throwable $error
    * @param $operation
    * @param \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexInterface $plugin_instance
-   * @param mixed|null $object
    * @param \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface $request_wrapper
+   * @param mixed|null $object
    */
-  public function __construct(\Throwable $error, $operation, ElasticsearchIndexInterface $plugin_instance, $object = NULL, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
+  public function __construct(\Throwable $error, $operation, ElasticsearchIndexInterface $plugin_instance, ElasticsearchRequestWrapperInterface $request_wrapper = NULL, $object = NULL) {
     $this->error = $error;
     $this->operation = $operation;
     $this->pluginInstance = $plugin_instance;
-    $this->object = $object;
     $this->requestWrapper = $request_wrapper;
+    $this->object = $object;
   }
 
   /**
@@ -102,19 +102,23 @@ class ElasticsearchOperationErrorEvent extends Event {
   }
 
   /**
-   * {@inheritdoc}
-   */
-  public function &getObject() {
-    return $this->object;
-  }
-
-  /**
    * Returns Elasticsearch request wrapper instance.
    *
    * @return \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface|null
    */
   public function getRequestWrapper() {
     return $this->requestWrapper;
+  }
+
+  /**
+   * Returns the actionable object.
+   *
+   * Value is returned by reference as actionable object can be of any type.
+   *
+   * @return mixed|null
+   */
+  public function &getObject() {
+    return $this->object;
   }
 
   /**

--- a/src/Event/ElasticsearchOperationEvent.php
+++ b/src/Event/ElasticsearchOperationEvent.php
@@ -72,6 +72,8 @@ class ElasticsearchOperationEvent extends Event implements OperationPermissionIn
   /**
    * Returns the actionable object.
    *
+   * Value is returned by reference as actionable object can be of any type.
+   *
    * @return mixed|null
    */
   public function &getObject() {

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -181,12 +181,13 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @param \Throwable $error
    * @param $operation
+   * @param mixed|null $source
    * @param \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface|null $request_wrapper
    *
    * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent
    */
-  protected function dispatchOperationErrorEvent(\Throwable $error, $operation, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
-    $event = new ElasticsearchOperationErrorEvent($error, $operation, $this, $request_wrapper);
+  protected function dispatchOperationErrorEvent(\Throwable $error, $operation, $source = NULL, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
+    $event = new ElasticsearchOperationErrorEvent($error, $operation, $this, $source, $request_wrapper);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_ERROR, $event);
 
     return $event;
@@ -198,7 +199,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @param $operation
    * @param $callback
    * @param array $request_params
-   * @param null $source
+   * @param mixed|null $source
    *
    * @return \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface
    */
@@ -224,7 +225,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, ElasticsearchOperations::INDEX_CREATE, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, ElasticsearchOperations::INDEX_CREATE, NULL, $request_wrapper);
     }
   }
 
@@ -253,7 +254,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
     }
   }
 
@@ -275,7 +276,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
 
       throw $e;
     }
@@ -317,7 +318,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
     }
   }
 
@@ -350,7 +351,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
     }
   }
 
@@ -376,7 +377,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
 
       throw $e;
     }
@@ -413,7 +414,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
     }
   }
 
@@ -442,7 +443,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
     }
   }
 
@@ -466,7 +467,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $params, $request_wrapper);
 
       throw $e;
     }
@@ -492,7 +493,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $params, $request_wrapper);
 
       throw $e;
     }
@@ -523,7 +524,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $body, $request_wrapper);
     }
   }
 

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -181,13 +181,13 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    *
    * @param \Throwable $error
    * @param $operation
-   * @param mixed|null $source
    * @param \Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface|null $request_wrapper
+   * @param mixed|null $source
    *
    * @return \Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent
    */
-  protected function dispatchOperationErrorEvent(\Throwable $error, $operation, $source = NULL, ElasticsearchRequestWrapperInterface $request_wrapper = NULL) {
-    $event = new ElasticsearchOperationErrorEvent($error, $operation, $this, $source, $request_wrapper);
+  protected function dispatchOperationErrorEvent(\Throwable $error, $operation, ElasticsearchRequestWrapperInterface $request_wrapper = NULL, $source = NULL) {
+    $event = new ElasticsearchOperationErrorEvent($error, $operation, $this, $request_wrapper, $source);
     $this->getEventDispatcher()->dispatch(ElasticsearchEvents::OPERATION_ERROR, $event);
 
     return $event;
@@ -225,7 +225,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, ElasticsearchOperations::INDEX_CREATE, NULL, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, ElasticsearchOperations::INDEX_CREATE, $request_wrapper);
     }
   }
 
@@ -254,7 +254,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
     }
   }
 
@@ -276,7 +276,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
 
       throw $e;
     }
@@ -318,7 +318,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, NULL, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper);
     }
   }
 
@@ -351,7 +351,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $source);
     }
   }
 
@@ -377,7 +377,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $source);
 
       throw $e;
     }
@@ -414,7 +414,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $source);
     }
   }
 
@@ -443,7 +443,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $source, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $source);
     }
   }
 
@@ -467,7 +467,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $params, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $params);
 
       throw $e;
     }
@@ -493,7 +493,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $params, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $params);
 
       throw $e;
     }
@@ -524,7 +524,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     }
     catch (\Throwable $e) {
       $request_wrapper = isset($request_wrapper) ? $request_wrapper : NULL;
-      $this->dispatchOperationErrorEvent($e, $operation, $body, $request_wrapper);
+      $this->dispatchOperationErrorEvent($e, $operation, $request_wrapper, $body);
     }
   }
 


### PR DESCRIPTION
This gives event listeners access to original indexable object if error occurs prior to request wrapper instantiation.