### PR TITLE
Queue is suspended if a no-node-available error occurs during indexining via queue

### DIFF
--- a/elasticsearch_helper.services.yml
+++ b/elasticsearch_helper.services.yml
@@ -31,6 +31,11 @@ services:
     tags:
       - { name: event_subscriber }
 
+  elasticsearch_helper.queue_index_event_subscriber:
+    class: Drupal\elasticsearch_helper\EventSubscriber\QueueIndexEventSubscriber
+    tags:
+      - { name: event_subscriber }
+
   elasticsearch_helper.data_type_repository:
     class: Drupal\elasticsearch_helper\Elasticsearch\DataType\DataTypeRepository
     arguments: ['@event_dispatcher']

--- a/src/EventSubscriber/QueueIndexEventSubscriber.php
+++ b/src/EventSubscriber/QueueIndexEventSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\elasticsearch_helper\EventSubscriber;
+
+use Drupal\Core\Queue\SuspendQueueException;
+use Drupal\elasticsearch_helper\Plugin\QueueWorker\IndexingQueueWorker;
+use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
+use Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent;
+use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Queue indexing event subscriber.
+ */
+class QueueIndexEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [];
+    $events[ElasticsearchEvents::OPERATION_ERROR][] = ['onQueueIndexError'];
+
+    return $events;
+  }
+
+  /**
+   * Suspends queue execution if no nodes are available.
+   *
+   * @param \Drupal\elasticsearch_helper\Event\ElasticsearchOperationErrorEvent $event
+   */
+  public function onQueueIndexError(ElasticsearchOperationErrorEvent $event) {
+    $index_with_queue = &drupal_static(IndexingQueueWorker::QUEUE_INDEXING_VAR_NAME);
+
+    if ($index_with_queue && $event->getError() instanceof NoNodesAvailableException) {
+      throw new SuspendQueueException();
+    }
+  }
+
+}

--- a/src/Plugin/QueueWorker/IndexingQueueWorker.php
+++ b/src/Plugin/QueueWorker/IndexingQueueWorker.php
@@ -86,9 +86,13 @@ class IndexingQueueWorker extends QueueWorkerBase implements ContainerFactoryPlu
     if ($entity) {
       // Set a global static variable which could be used by other modules to
       // identify that the indexing is happening from the queue worker operation.
-      $indexWithQueue = &drupal_static(self::QUEUE_INDEXING_VAR_NAME);
-      $indexWithQueue = TRUE;
+      $index_with_queue = &drupal_static(self::QUEUE_INDEXING_VAR_NAME);
+      $index_with_queue = TRUE;
+
+      // Index the entity.
       $this->elasticsearchIndexManager->indexEntity($entity);
+
+      // Reset global static.
       drupal_static_reset(self::QUEUE_INDEXING_VAR_NAME);
     }
   }


### PR DESCRIPTION
This change suspends the indexing queue execution if no-node-available error occurs during indexing via queue.

Steps to review:
1. Run `lando drush cr`
2. Run `lando drush eshr` to create indexing queue
3. Stop Elasticsearch instance via Docker Dashboard
4. Run `lando drush cron`, see that an error is displayed that _could not index document "X"_. See that items in `queue_elasticsearch_helper` are still there and not cleared.