### PR TITLE
Hook "elasticsearch_helper_reindex_entity_query_alter" is added

### DIFF
--- a/elasticsearch_helper.api.php
+++ b/elasticsearch_helper.api.php
@@ -5,6 +5,8 @@
  * Hooks provided by the elasticsearch_helper module.
  */
 
+use \Drupal\Core\Entity\Query\QueryInterface;
+
 /**
  * @addtogroup hooks
  * @{
@@ -19,6 +21,21 @@
 function hook_elasticsearch_helper_client_builder_alter(\Elasticsearch\ClientBuilder $clientBuilder) {
   // Send log entries from the client directly to Drupal's log.
   $clientBuilder->setLogger(\Drupal::logger('elasticsearch'));
+}
+
+/**
+ * Alters the entity query which selects entities for reindexing.
+ *
+ * @param \Drupal\Core\Entity\Query\QueryInterface $query
+ *   Entity query instance.
+ * @param $entity_type
+ *   Type of entities which need to be re-indexed.
+ * @param string|null $bundle
+ *   Optional bundle name.
+ */
+function hook_elasticsearch_helper_reindex_entity_query_alter(QueryInterface $query, $entity_type, $bundle = NULL) {
+  // Do not restrict entity query based on user's permissions or node grants.
+  $query->accessCheck(FALSE);
 }
 
 /**

--- a/elasticsearch_helper.module
+++ b/elasticsearch_helper.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
 
 /**
  * Implements hook_entity_insert().
@@ -77,4 +78,16 @@ function elasticsearch_helper_module_preuninstall($module) {
       $index_plugin_manager->createInstance($plugin['id'])->drop();
     }
   }
+}
+
+/**
+ * Implements hook_elasticsearch_helper_reindex_entity_query_alter().
+ */
+function elasticsearch_helper_elasticsearch_helper_reindex_entity_query_alter(QueryInterface $query, $entity_type, $bundle = NULL) {
+  // Do not restrict entity query based on user's permissions or node grants.
+  // Generally all entities are considered to be re-indexed when
+  // "drush elasticsearch-helper-reindex" command is run or
+  // \Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager::reindexEntities()
+  // is executed.
+  $query->accessCheck(FALSE);
 }

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -155,6 +155,10 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
       $query->condition($entity_type_instance->getKey('bundle'), $bundle);
     }
 
+    // Allow other modules to alter the entity query prior to execution.
+    $this->moduleHandler->alter('elasticsearch_helper_reindex_entity_query', $query, $entity_type, $bundle);
+
+    // Execute the entity query.
     $result = $query->execute();
 
     // Queue entities for reindexing.


### PR DESCRIPTION
Hook `elasticsearch_helper_reindex_entity_query_alter` added to allow modules to alter entity query which selects the entities for reindexing.

The problem has been raised by @k4lv15. By default, if project has a module which uses node grants, entity query used in `ElasticsearchIndexManager::reindexEntities()` is returning entities which are not captured by node grants. In the result running `drush eshr` would not produce the reindexing of all entities managed by index plugins but rather a limited set of entities where nodes with node grant entries are filtered out.

This change adds a generic alter hook into `ElasticsearchIndexManager::reindexEntities()` allowing modules (incl. `elasticsearch_helper` module itself) to alter reindex entity query.

The assumtion has always been that reindex entities command reindexes all the entities regardless of their publishing status or other restrictions. While some projects where Elasticsearch Helper in concert with node grant modules produce a limited set of results may consider this change a breaking change, it's best if this issue is resolved in a manner which is flexible enough to implement a workaround if needed.

Steps to review:
1. Run `drush cr`
2. Enable a module which enables node grants (e.g., https://www.drupal.org/project/tac_lite)
3. See that all entities of an entity type are queued for reindex when you run `drush eshr` command which reindexes the entities managed by an index plugin.