### PR TITLE
Fixed typo in permission settings

### DIFF
--- a/elasticsearch_helper.routing.yml
+++ b/elasticsearch_helper.routing.yml
@@ -5,6 +5,6 @@ elasticsearch_helper.elasticsearch_helper_settings_form:
     _form: '\Drupal\elasticsearch_helper\Form\ElasticsearchHelperSettingsForm'
     _title: 'Elasticsearch Helper Settings'
   requirements:
-    _permission: 'configured elasticsearch helper'
+    _permission: 'configure elasticsearch helper'
   options:
     _admin_route: TRUE


### PR DESCRIPTION
Elasticsearch Helper Settings page (and related menu item link) is currently available only for administrators and doesn't follow intended ElasticSearch Helper related permission due to typo in permission name in routing definitions.