### PR TITLE
Fix compatibility with entity level access control

### DIFF
--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -149,7 +149,8 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
    */
   public function reindexEntities($entity_type, $bundle = NULL) {
     $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
-
+    // Ensure the entity level access control doesn't prevent indexing.
+    $query->accessCheck(FALSE);
     if ($bundle) {
       $entity_type_instance = $this->entityTypeManager->getDefinition($entity_type);
       $query->condition($entity_type_instance->getKey('bundle'), $bundle);


### PR DESCRIPTION
Example problem case:
Reindexing fails with node_view_permissions module enabled and permissions rebuilt (/admin/reports/status/rebuild).