### PR TITLE
Feature: Pluggable client

### DIFF
--- a/elasticsearch_helper.install
+++ b/elasticsearch_helper.install
@@ -36,10 +36,10 @@ function elasticsearch_helper_requirements($phase) {
     else {
       // Check Elasticsearch status.
       /** @var \Elasticsearch\Client $client */
-      $client = \Drupal::service('elasticsearch_helper.elasticsearch_client');
+      $client = \Drupal::service('elasticsearch_helper.client.default');
 
       try {
-        $health = $client->cluster()->health();
+        $health = $client->health();
 
         $color_states = [
           'green' => REQUIREMENT_OK,

--- a/elasticsearch_helper.services.yml
+++ b/elasticsearch_helper.services.yml
@@ -3,14 +3,6 @@ services:
     parent: logger.channel_base
     arguments: ['elasticsearch_helper']
 
-  elasticsearch_helper.elasticsearch_client:
-    class: Elasticsearch\Client
-    factory: elasticsearch_helper.elasticsearch_client_builder:build
-
-  elasticsearch_helper.elasticsearch_client_builder:
-    class: Drupal\elasticsearch_helper\ElasticsearchClientBuilder
-    arguments: ['@config.factory', '@module_handler']
-
   plugin.manager.elasticsearch_index.processor:
     class: Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@entity_type.manager', '@queue', '@logger.factory']

--- a/elasticsearch_helper.services.yml
+++ b/elasticsearch_helper.services.yml
@@ -45,4 +45,4 @@ services:
 
   elasticsearch_helper.client.default:
     class: Drupal\elasticsearch_helper\ElasticsearchHelperClient
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@module_handler']

--- a/elasticsearch_helper.services.yml
+++ b/elasticsearch_helper.services.yml
@@ -50,3 +50,7 @@ services:
     decorates: queue
     arguments: ['@elasticsearch_helper.queue_factory_decorator.inner', '@settings']
     decoration_priority: 3
+
+  elasticsearch_helper.client.default:
+    class: Drupal\elasticsearch_helper\ElasticsearchHelperClient
+    arguments: ['@config.factory']

--- a/examples/elasticsearch_helper_example/elasticsearch_helper_example.services.yml
+++ b/examples/elasticsearch_helper_example/elasticsearch_helper_example.services.yml
@@ -8,3 +8,7 @@ services:
     class: Drupal\elasticsearch_helper_example\EventSubscriber\ReindexEventSubscriber
     tags:
       - { name: event_subscriber }
+
+  elasticsearch_helper.client.custom:
+    class: Drupal\elasticsearch_helper_example\CustomClient
+    arguments: []

--- a/examples/elasticsearch_helper_example/src/CustomClient.php
+++ b/examples/elasticsearch_helper_example/src/CustomClient.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_example;
+
+use Drupal\elasticsearch_helper\ClientInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+
+/**
+ * Elasticsearch Helper Custom Client.
+ *
+ * This is only an example and does not actually have a real api to connect to.
+ */
+class CustomClient implements ClientInterface {
+
+  /**
+   * Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig definition.
+   *
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * GuzzleHttp\Client definition.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  protected $client;
+
+  /**
+   * Constructs a new CustomClient object.
+   */
+  public function __construct() {
+    $this->client = $this->build();
+  }
+
+  /**
+   * Create an elasticsearch client.
+   */
+  public function build() {
+    // Initialize the custom client here.
+    $token = 'SomeToken';
+    $base_url = 'http://localhost/api/custom';
+
+    $clientConfig = [
+      'base_uri' => $base_url,
+      RequestOptions::HEADERS =>
+        [
+          'Authorization' => "Basic {$token}",
+        ],
+
+    ];
+
+    $this->client = new Client($clientConfig);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function index(array $parameters) {
+    $this->client->post('index', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function update(array $parameters) {
+    $this->client->post('update', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(array $parameters) {
+    $this->client->post('delete', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function search(array $parameters) {
+    $this->client->post('search', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function msearch(array $parameters) {
+    $this->client->post('msearch', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function bulk(array $parameters) {
+    $this->client->post('bulk', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function indices(array $parameters = []) {
+    $this->client->post('get_indices', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createIndex(array $parameters) {
+    $this->client->post('create_index', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteIndex(array $parameters) {
+    $this->client->post('delete_index', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function health() {
+    $this->client->post('health');
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function indexExists($name) {
+    $this->client->post('index_exists/' . $name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function templateExists($name) {
+    $this->client->post('template/' . $name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function putTemplate(array $parameters) {
+    $this->client->post('put_template', [
+      RequestOptions::JSON => $parameters,
+    ]);
+  }
+
+}

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/IndexWithCustomClient.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/IndexWithCustomClient.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
+use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
+use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Define a custom index that uses a custom client.
+ *
+ * @ElasticsearchIndex(
+ *   id = "custom_client_index",
+ *   label = @Translation("Index with custom client"),
+ *   indexName = "custom_client_index",
+ *   typeName = "node",
+ *   entityType = "node"
+ * )
+ */
+class IndexWithCustomClient extends ElasticsearchIndexBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      // Inject custom client.
+      $container->get('elasticsearch_helper.client.custom'),
+      $container->get('serializer'),
+      $container->get('logger.factory')->get('elasticsearch_helper')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappingDefinition(array $context = []) {
+    $user_property = FieldDefinition::create('object')
+      ->addProperty('uid', FieldDefinition::create('integer'))
+      ->addProperty('name', FieldDefinition::create('keyword'));
+
+    return MappingDefinition::create()
+      ->addProperty('id', FieldDefinition::create('integer'))
+      ->addProperty('uuid', FieldDefinition::create('keyword'))
+      ->addProperty('title', FieldDefinition::create('text'))
+      ->addProperty('status', FieldDefinition::create('keyword'))
+      ->addProperty('user', $user_property);
+  }
+
+}

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -5,9 +5,9 @@ namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
+use Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface;
 use Drupal\elasticsearch_helper\ElasticsearchLanguageAnalyzer;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
-use Elasticsearch\Client;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Serializer\Serializer;
@@ -34,12 +34,12 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
    * @param array $configuration
    * @param $plugin_id
    * @param $plugin_definition
-   * @param \Elasticsearch\Client $client
+   * @param \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface $client
    * @param \Symfony\Component\Serializer\Serializer $serializer
    * @param \Psr\Log\LoggerInterface $logger
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Client $client, Serializer $serializer, LoggerInterface $logger, LanguageManagerInterface $language_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ElasticsearchHelperClientInterface $client, Serializer $serializer, LoggerInterface $logger, LanguageManagerInterface $language_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $client, $serializer, $logger);
 
     $this->language_manager = $language_manager;
@@ -53,7 +53,7 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('elasticsearch_helper.elasticsearch_client'),
+      $container->get('elasticsearch_helper.client.default'),
       $container->get('serializer'),
       $container->get('logger.factory')->get('elasticsearch_helper'),
       $container->get('language_manager')
@@ -106,7 +106,7 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
       $index_name = $this->getIndexName(['langcode' => $langcode]);
 
       // Check if index exists.
-      if (!$this->client->indices()->exists(['index' => $index_name])) {
+      if (!$this->client->indexExists($index_name)) {
         // Get index definition.
         $index_definition = $this->getIndexDefinition(['langcode' => $langcode]);
 

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/MultilingualContentIndex.php
@@ -5,7 +5,7 @@ namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
-use Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface;
+use Drupal\elasticsearch_helper\ClientInterface;
 use Drupal\elasticsearch_helper\ElasticsearchLanguageAnalyzer;
 use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
 use Psr\Log\LoggerInterface;
@@ -34,12 +34,12 @@ class MultilingualContentIndex extends ElasticsearchIndexBase {
    * @param array $configuration
    * @param $plugin_id
    * @param $plugin_definition
-   * @param \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface $client
+   * @param \Drupal\elasticsearch_helper\ClientInterface $client
    * @param \Symfony\Component\Serializer\Serializer $serializer
    * @param \Psr\Log\LoggerInterface $logger
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ElasticsearchHelperClientInterface $client, Serializer $serializer, LoggerInterface $logger, LanguageManagerInterface $language_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ClientInterface $client, Serializer $serializer, LoggerInterface $logger, LanguageManagerInterface $language_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $client, $serializer, $logger);
 
     $this->language_manager = $language_manager;

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/TimeBasedIndex.php
@@ -45,8 +45,8 @@ class TimeBasedIndex extends ElasticsearchIndexBase {
       $operation = ElasticsearchOperations::INDEX_TEMPLATE_CREATE;
       $template_name = $this->getPluginId();
 
-      if (!$this->client->indices()->existsTemplate(['name' => $template_name])) {
-        $callback = [$this->client->indices(), 'putTemplate'];
+      if (!$this->client->templateExists($template_name)) {
+        $callback = [$this->client, 'putTemplate'];
 
         $request_params = [
           'name' => $template_name,

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,7 +3,7 @@
 namespace Drupal\elasticsearch_helper;
 
 /**
- * Interface for classes that implements a client service.
+ * Provides an interface for Elasticsearch Helper clients.
  */
 interface ClientInterface {
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,9 +3,9 @@
 namespace Drupal\elasticsearch_helper;
 
 /**
- * Interface for Elasticsearch Helper Client.
+ * Interface for classes that implements a client service.
  */
-interface ElasticsearchHelperClientInterface {
+interface ClientInterface {
 
   /**
    * Index operation.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -81,6 +81,9 @@ interface ClientInterface {
 
   /**
    * Get cluster health.
+   *
+   * @return array
+   *   An array containing information about cluster health.
    */
   public function health();
 
@@ -89,6 +92,9 @@ interface ClientInterface {
    *
    * @param string $name
    *   The name of the index.
+   *
+   * @return bool
+   *   Return TRUE if the index exists.
    */
   public function indexExists($name);
 
@@ -97,6 +103,9 @@ interface ClientInterface {
    *
    * @param string $name
    *   The template name.
+   *
+   * @return bool
+   *   Return TRUE if the template exists.
    */
   public function templateExists($name);
 

--- a/src/ElasticsearchClientBuilder.php
+++ b/src/ElasticsearchClientBuilder.php
@@ -9,6 +9,8 @@ use Elasticsearch\ClientBuilder;
 /**
  * Class ElasticsearchClientBuilder.
  *
+ * @deprecated
+ *
  * @package Drupal\elasticsearch_helper
  */
 class ElasticsearchClientBuilder {

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -102,7 +102,7 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
    * {@inheritdoc}
    */
   public function delete(array $parameters) {
-    return $this->client->update($parameters);
+    return $this->client->delete($parameters);
   }
 
   /**

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -119,7 +119,7 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function indices(array $parameters) {
+  public function indices(array $parameters = []) {
     return $this->client->indices()->get($parameters);
   }
 

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -126,6 +126,20 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   /**
    * {@inheritdoc}
    */
+  public function createIndex(array $parameters) {
+    $this->client->indices()->create($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteIndex(array $parameters) {
+    $this->client->indices()->delete($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function health() {
     return $this->client->cluster()->health();
 

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -12,11 +12,11 @@ use Elasticsearch\ClientBuilder;
 class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
 
   /**
-   * Drupal\Core\Config\ConfigFactoryInterface definition.
+   * Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig definition.
    *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
    */
-  protected $configFactory;
+  protected $config;
 
   /**
    * Elasticsearch\Client definition.
@@ -36,8 +36,7 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
    * Constructs a new ElasticsearchHelperClient object.
    */
   public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler) {
-    $this->configFactory = $config_factory;
-
+    $this->config = $config_factory->get('elasticsearch_helper.settings');
     $this->moduleHandler = $module_handler;
     $this->client = $this->build();
   }
@@ -64,7 +63,7 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   protected function getHosts() {
     $hosts = [];
 
-    foreach ($this->configFactory->get('hosts') as $host_config) {
+    foreach ($this->config->get('hosts') as $host_config) {
       $host = ElasticsearchHost::createFromArray($host_config);
 
       $host_entry = [

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -3,6 +3,7 @@
 namespace Drupal\elasticsearch_helper;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Elasticsearch\ClientBuilder;
 
 /**
@@ -25,11 +26,19 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   protected $client;
 
   /**
+   * Drupal\Core\Extension\ModuleHandler definition.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandler
+   */
+  protected $moduleHandler;
+
+  /**
    * Constructs a new ElasticsearchHelperClient object.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler) {
     $this->configFactory = $config_factory;
 
+    $this->moduleHandler = $module_handler;
     $this->client = $this->build();
   }
 
@@ -55,7 +64,7 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   protected function getHosts() {
     $hosts = [];
 
-    foreach ($this->config->get('hosts') as $host_config) {
+    foreach ($this->configFactory->get('hosts') as $host_config) {
       $host = ElasticsearchHost::createFromArray($host_config);
 
       $host_entry = [

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -119,8 +119,8 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function indices() {
-    return $this->client->indices()->get();
+  public function indices(array $parameters) {
+    return $this->client->indices()->get($parameters);
   }
 
   /**

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -29,6 +29,8 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
    */
   public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;
+
+    $this->client = $this->build();
   }
 
   /**

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Elasticsearch Helper Default Client.
+ */
+class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
+
+  /**
+   * Drupal\Core\Config\ConfigFactoryInterface definition.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new ElasticsearchHelperClient object.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+}

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -9,7 +9,7 @@ use Elasticsearch\ClientBuilder;
 /**
  * Elasticsearch Helper Default Client.
  */
-class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
+class ElasticsearchHelperClient implements ClientInterface {
 
   /**
    * Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig definition.

--- a/src/ElasticsearchHelperClient.php
+++ b/src/ElasticsearchHelperClient.php
@@ -3,6 +3,7 @@
 namespace Drupal\elasticsearch_helper;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Elasticsearch\ClientBuilder;
 
 /**
  * Elasticsearch Helper Default Client.
@@ -17,10 +18,138 @@ class ElasticsearchHelperClient implements ElasticsearchHelperClientInterface {
   protected $configFactory;
 
   /**
+   * Elasticsearch\Client definition.
+   *
+   * @var \Elasticsearch\Client
+   */
+  protected $client;
+
+  /**
    * Constructs a new ElasticsearchHelperClient object.
    */
   public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Create an elasticsearch client.
+   *
+   * @return \Elasticsearch\Client
+   *   Return the client.
+   */
+  public function build() {
+    $clientBuilder = ClientBuilder::create();
+    $clientBuilder->setHosts($this->getHosts());
+
+    // Let other modules set their own handlers.
+    $this->moduleHandler->alter('elasticsearch_helper_client_builder', $clientBuilder);
+
+    return $clientBuilder->build();
+  }
+
+  /**
+   * Get the hosts based on the site configuration.
+   */
+  protected function getHosts() {
+    $hosts = [];
+
+    foreach ($this->config->get('hosts') as $host_config) {
+      $host = ElasticsearchHost::createFromArray($host_config);
+
+      $host_entry = [
+        'host' => $host->getHost(),
+        'port' => $host->getPort(),
+        'scheme' => $host->getScheme(),
+      ];
+
+      if ($host->isAuthEnabled()) {
+        $host_entry['user'] = $host->getAuthUsername();
+        $host_entry['pass'] = $host->getAuthPassword();
+      }
+
+      // Use only explicitly defined configuration.
+      $hosts[] = array_filter($host_entry);
+    }
+
+    return $hosts;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function index(array $parameters) {
+    return $this->client->index($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function update(array $parameters) {
+    return $this->client->update($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete(array $parameters) {
+    return $this->client->update($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function search(array $parameters) {
+    return $this->client->search($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function msearch(array $parameters) {
+    return $this->client->msearch($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function bulk(array $parameters) {
+    return $this->client->bulk($parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function indices() {
+    return $this->client->indices()->get();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function health() {
+    return $this->client->cluster()->health();
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function indexExists($name) {
+    return $this->client->indices()->exists(['index' => $name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function templateExists($name) {
+    return $this->client->indices()->existsTemplate(['name' => $name]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function putTemplate(array $parameters) {
+    return $this->client->indices()->putTemplate($parameters);
   }
 
 }

--- a/src/ElasticsearchHelperClientInterface.php
+++ b/src/ElasticsearchHelperClientInterface.php
@@ -61,6 +61,22 @@ interface ElasticsearchHelperClientInterface {
   public function indices();
 
   /**
+   * Create index operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function createIndex(array $parameters);
+
+  /**
+   * Delete index operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function deleteIndex(array $parameters);
+
+  /**
    * Get cluster health.
    */
   public function health();

--- a/src/ElasticsearchHelperClientInterface.php
+++ b/src/ElasticsearchHelperClientInterface.php
@@ -61,7 +61,7 @@ interface ElasticsearchHelperClientInterface {
    * @param array $parameters
    *   The array of request parameters.
    */
-  public function indices(array $parameters);
+  public function indices(array $parameters = []);
 
   /**
    * Create index operation.

--- a/src/ElasticsearchHelperClientInterface.php
+++ b/src/ElasticsearchHelperClientInterface.php
@@ -57,8 +57,11 @@ interface ElasticsearchHelperClientInterface {
 
   /**
    * Get indices.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
    */
-  public function indices();
+  public function indices(array $parameters);
 
   /**
    * Create index operation.

--- a/src/ElasticsearchHelperClientInterface.php
+++ b/src/ElasticsearchHelperClientInterface.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\elasticsearch_helper;
+
+/**
+ * Interface for Elasticsearch Helper Client.
+ */
+interface ElasticsearchHelperClientInterface {
+
+  /**
+   * Index operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function index(array $parameters);
+
+  /**
+   * Update operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function update(array $parameters);
+
+  /**
+   * Delete operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function delete(array $parameters);
+
+  /**
+   * Search operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function search(array $parameters);
+
+  /**
+   * MSearch operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function msearch(array $parameters);
+
+  /**
+   * Bulk operation.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function bulk(array $parameters);
+
+  /**
+   * Get indices.
+   */
+  public function indices();
+
+  /**
+   * Get cluster health.
+   */
+  public function health();
+
+  /**
+   * Check if index exists.
+   *
+   * @param string $name
+   *   The name of the index.
+   */
+  public function indexExists($name);
+
+  /**
+   * Check if template exists.
+   *
+   * @param string $name
+   *   The template name.
+   */
+  public function templateExists($name);
+
+  /**
+   * Put a template to index.
+   *
+   * @param array $parameters
+   *   The array of request parameters.
+   */
+  public function putTemplate(array $parameters);
+
+}

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -5,7 +5,7 @@ namespace Drupal\elasticsearch_helper\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface;
+use Drupal\elasticsearch_helper\ClientInterface;
 use Drupal\elasticsearch_helper\ElasticsearchHost;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
@@ -19,7 +19,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
   /**
    * The Elasticsearch client.
    *
-   * @var \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface
+   * @var \Drupal\elasticsearch_helper\ClientInterface
    */
   protected $client;
 
@@ -35,10 +35,10 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
-   * @param \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface $elasticsearch_client
+   * @param \Drupal\elasticsearch_helper\ClientInterface $elasticsearch_client
    *   The Elasticsearch client.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, ElasticsearchHelperClientInterface $elasticsearch_client) {
+  public function __construct(ConfigFactoryInterface $config_factory, ClientInterface $elasticsearch_client) {
     parent::__construct($config_factory);
 
     $this->client = $elasticsearch_client;

--- a/src/Form/ElasticsearchHelperSettingsForm.php
+++ b/src/Form/ElasticsearchHelperSettingsForm.php
@@ -5,6 +5,7 @@ namespace Drupal\elasticsearch_helper\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface;
 use Drupal\elasticsearch_helper\ElasticsearchHost;
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\NoNodesAvailableException;
@@ -18,7 +19,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
   /**
    * The Elasticsearch client.
    *
-   * @var \Elasticsearch\Client
+   * @var \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface
    */
   protected $client;
 
@@ -34,10 +35,10 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
-   * @param \Elasticsearch\Client $elasticsearch_client
+   * @param \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface $elasticsearch_client
    *   The Elasticsearch client.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, Client $elasticsearch_client) {
+  public function __construct(ConfigFactoryInterface $config_factory, ElasticsearchHelperClientInterface $elasticsearch_client) {
     parent::__construct($config_factory);
 
     $this->client = $elasticsearch_client;
@@ -50,7 +51,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('elasticsearch_helper.elasticsearch_client')
+      $container->get('elasticsearch_helper.client.default')
     );
   }
 
@@ -95,7 +96,7 @@ class ElasticsearchHelperSettingsForm extends ConfigFormBase {
    * @throws \Exception
    */
   protected function getServerHealthStatus() {
-    $result = $this->client->cluster()->health();
+    $result = $this->client->health();
 
     return $result['status'];
   }

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -10,6 +10,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
 use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
+use Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface;
 use Drupal\elasticsearch_helper\ElasticsearchRequestWrapper;
 use Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface;
 use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
@@ -18,7 +19,6 @@ use Drupal\elasticsearch_helper\Event\ElasticsearchHelperEvents;
 use Drupal\elasticsearch_helper\Event\ElasticsearchHelperCallbackEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperationEvent;
 use Drupal\elasticsearch_helper\Event\ElasticsearchOperations;
-use Elasticsearch\Client;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Psr\Log\LoggerInterface;
@@ -32,7 +32,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   use MessengerTrait;
 
   /**
-   * @var \Elasticsearch\Client
+   * @var \Drupal\elasticsearch_helper\ElasticsearchHelperClient
    */
   protected $client;
 
@@ -80,11 +80,11 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @param array $configuration
    * @param string $plugin_id
    * @param mixed $plugin_definition
-   * @param \Elasticsearch\Client $client
+   * @param \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface $client
    * @param \Symfony\Component\Serializer\Serializer $serializer
    * @param \Psr\Log\LoggerInterface $logger
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, Client $client, Serializer $serializer, LoggerInterface $logger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ElasticsearchHelperClientInterface $client, Serializer $serializer, LoggerInterface $logger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->client = $client;
@@ -104,7 +104,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('elasticsearch_helper.elasticsearch_client'),
+      $container->get('elasticsearch_helper.client.default'),
       $container->get('serializer'),
       $container->get('logger.factory')->get('elasticsearch_helper')
     );
@@ -218,7 +218,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       if ($index_definition = $this->getIndexDefinition()) {
         $index_name = $this->getIndexName();
 
-        if (!$this->client->indices()->exists(['index' => $index_name])) {
+        if (!$this->client->indexExists($index_name)) {
           $this->createIndex($index_name, $index_definition);
         }
       }
@@ -241,7 +241,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $operation_event = $this->dispatchOperationEvent($operation, $index_name);
 
       if ($operation_event->isOperationAllowed()) {
-        $callback = [$this->client->indices(), 'create'];
+        $callback = [$this->client, 'createIndex'];
         $request_params = [
           'index' => $index_name,
           'body' => $index_definition->toArray(),
@@ -265,7 +265,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
     try {
       $operation = ElasticsearchOperations::INDEX_GET;
 
-      $callback = [$this->client->indices(), 'get'];
+      $callback = [$this->client, 'indices'];
       $request_params = ['index' => $this->indexNamePattern()];
 
       // Get a list of indices.
@@ -308,7 +308,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
           }
 
           // Delete matching indices.
-          $callback = [$this->client->indices(), 'delete'];
+          $callback = [$this->client, 'deleteIndex'];
           $request_params = ['index' => $index];
 
           $request_wrapper = $this->createRequest($operation, $callback, $request_params);

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -10,7 +10,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\IndexDefinition;
 use Drupal\elasticsearch_helper\Elasticsearch\Index\SettingsDefinition;
 use Drupal\elasticsearch_helper\ElasticsearchClientVersion;
-use Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface;
+use Drupal\elasticsearch_helper\ClientInterface;
 use Drupal\elasticsearch_helper\ElasticsearchRequestWrapper;
 use Drupal\elasticsearch_helper\ElasticsearchRequestWrapperInterface;
 use Drupal\elasticsearch_helper\Event\ElasticsearchEvents;
@@ -80,11 +80,11 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
    * @param array $configuration
    * @param string $plugin_id
    * @param mixed $plugin_definition
-   * @param \Drupal\elasticsearch_helper\ElasticsearchHelperClientInterface $client
+   * @param \Drupal\elasticsearch_helper\ClientInterface $client
    * @param \Symfony\Component\Serializer\Serializer $serializer
    * @param \Psr\Log\LoggerInterface $logger
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ElasticsearchHelperClientInterface $client, Serializer $serializer, LoggerInterface $logger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ClientInterface $client, Serializer $serializer, LoggerInterface $logger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
     $this->client = $client;

--- a/tests/src/Kernel/IndexTest.php
+++ b/tests/src/Kernel/IndexTest.php
@@ -43,7 +43,7 @@ class IndexTest extends EntityKernelTestBase {
     // Delete any pre-existing indices.
     // @TODO, Setup mapping.
     try {
-      $client = \Drupal::service('elasticsearch_helper.elasticsearch_client');
+      $client = \Drupal::service('elasticsearch_helper.client.default');
       $client->indices()->delete(['index' => 'simple']);
     }
     catch (\Exception $e) {

--- a/tests/src/Kernel/IndexTest.php
+++ b/tests/src/Kernel/IndexTest.php
@@ -44,7 +44,7 @@ class IndexTest extends EntityKernelTestBase {
     // @TODO, Setup mapping.
     try {
       $client = \Drupal::service('elasticsearch_helper.client.default');
-      $client->indices()->delete(['index' => 'simple']);
+      $client->deleteIndex(['index' => 'simple']);
     }
     catch (\Exception $e) {
       // Do nothing.


### PR DESCRIPTION
### Problem/Motivation

Elasticsearch helper client currently has a somewhat hard dependency with the Elasticsearch PHP client. This works ok for most cases, but there has been cases where Elasticsearch is behind a proxy API, and the API has a different request format.

There has also been proposal for expanding the capabilities of the module to allow the use other search backend engines in the future. This would be a first step towards that direction also.

### Proposed solution

- Refactor the client as a service
- Deprecate the old client builder
- Create a default client, which uses the Elasticsearch PHP client
- Add a client interface which would enforces the methods and attributes of existing and future clients
- Updated Index base class to use the new client and interface

I have added an example index that uses a custom client as an example of how to use this.

### Possible issues

- This would create breaking changes for projects and modules that calls the client directly, or have implemented custom index methods