### PR TITLE
Revert "Fix compatibility with entity level access control"

### DIFF
--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -149,8 +149,7 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
    */
   public function reindexEntities($entity_type, $bundle = NULL) {
     $query = $this->entityTypeManager->getStorage($entity_type)->getQuery();
-    // Ensure the entity level access control doesn't prevent indexing.
-    $query->accessCheck(FALSE);
+
     if ($bundle) {
       $entity_type_instance = $this->entityTypeManager->getDefinition($entity_type);
       $query->condition($entity_type_instance->getKey('bundle'), $bundle);


### PR DESCRIPTION
Reverts wunderio/elasticsearch_helper#77 in favor of wunderio/elasticsearch_helper#74