### PR TITLE
Feature: Index caching

### DIFF
--- a/elasticsearch_helper.module
+++ b/elasticsearch_helper.module
@@ -5,7 +5,9 @@
  * This module provides tools to integrate elasticsearch with Drupal.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
 
 /**
  * Implements hook_entity_insert().
@@ -17,9 +19,14 @@ function elasticsearch_helper_entity_insert(EntityInterface $entity) {
   $index_plugin_manager = \Drupal::service('plugin.manager.elasticsearch_index.processor');
 
   if ($config->get('defer_indexing')) {
+    // Invalidate the serialized data cache for the entity that we are indexing.
+    Cache::invalidateTags([ElasticsearchIndexBase::CID_PREFIX . $entity->getEntityTypeId() . ':' . $entity->id()]);
     $index_plugin_manager->addToQueue($entity->getEntityTypeId(), $entity->id());
   }
   else {
+    // Invalidate cache would not work here, instead the cache should be
+    // explicitely deleted.
+    $index_plugin_manager->clearEntityCache($entity);
     $index_plugin_manager->indexEntity($entity);
   }
 }

--- a/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/NodeIndexCached.php
+++ b/examples/elasticsearch_helper_example/src/Plugin/ElasticsearchIndex/NodeIndexCached.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\elasticsearch_helper_example\Plugin\ElasticsearchIndex;
+
+use Drupal\elasticsearch_helper\Elasticsearch\Index\FieldDefinition;
+use Drupal\elasticsearch_helper\Elasticsearch\Index\MappingDefinition;
+use Drupal\elasticsearch_helper\Plugin\ElasticsearchIndexBase;
+
+/**
+ * An example index that uses caching.
+ *
+ * Cached indexes caches serialized data to speed up re-indexing processes.
+ *
+ * @ElasticsearchIndex(
+ *   id = "cached_node_index",
+ *   label = @Translation("Cached node index"),
+ *   indexName = "cached",
+ *   cache = TRUE,
+ *   typeName = "node",
+ *   entityType = "node"
+ * )
+ */
+class NodeIndexCached extends ElasticsearchIndexBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMappingDefinition(array $context = []) {
+    $user_property = FieldDefinition::create('object')
+      ->addProperty('uid', FieldDefinition::create('integer'))
+      ->addProperty('name', FieldDefinition::create('keyword'));
+
+    return MappingDefinition::create()
+      ->addProperty('id', FieldDefinition::create('integer'))
+      ->addProperty('uuid', FieldDefinition::create('keyword'))
+      ->addProperty('title', FieldDefinition::create('text'))
+      ->addProperty('status', FieldDefinition::create('keyword'))
+      ->addProperty('user', $user_property);
+  }
+}

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -609,10 +609,12 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
 
       // Store data to cache after serialization.
       if ($cached && $context['method'] == 'index') {
-        \Drupal::cache()->set($cache_id, $data, Cache::PERMANENT, [
-          'elasticsearch_cache',
-          $source->getEntityTypeId() . ':' . $source->id(),
-        ]);
+        $tags = [
+          'elasticsearch_helper_cache',
+          'elasticsearch_helper_cache:' . $source->getEntityTypeId() . ':' . $source->id(),
+        ];
+
+        \Drupal::cache()->set($cache_id, $data, Cache::PERMANENT, $tags);
       }
 
       return $data;

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -582,7 +582,7 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       $cached = isset($this->pluginDefinition['cache']) ? $this->pluginDefinition['cache'] : FALSE;
 
       // Set the cache id from entity attributes.
-      $cache_id = static::CID_PREFIX . 'entity:' . $source->getEntityTypeId() . ':' . $source->language()->getId() . ':' . $source->id();
+      $cache_id = $this->getCacheId($source);
 
       // Load a cached version of the data if it exists.
       // Cache should only be used when indexing content.
@@ -621,6 +621,20 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
       // Non-entities are simply kept as they are.
       return $source;
     }
+  }
+
+  /**
+   * Determine the cache id for the entity.
+   *
+   * @param Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to be cached.
+   *
+   * @return string
+   *   The cache id.
+   */
+  public function getCacheId(EntityInterface $entity) {
+    $index_id = $this->pluginDefinition['id'];
+    return static::CID_PREFIX . 'entity:' . $index_id . ':' . $entity->getEntityTypeId() . ':' . $entity->language()->getId() . ':' . $entity->id();
   }
 
   /**

--- a/src/Plugin/ElasticsearchIndexBase.php
+++ b/src/Plugin/ElasticsearchIndexBase.php
@@ -626,6 +626,20 @@ abstract class ElasticsearchIndexBase extends PluginBase implements Elasticsearc
   }
 
   /**
+   * Delete the entity's cached serialized data.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to be processed.
+   */
+  public function clearEntityCache(EntityInterface $entity) {
+    if ($entity instanceof EntityInterface) {
+      $cid = $this->getCacheId($entity);
+
+      \Drupal::cache()->delete($cid);
+    }
+  }
+
+  /**
    * Determine the cache id for the entity.
    *
    * @param Drupal\Core\Entity\EntityInterface $entity

--- a/src/Plugin/ElasticsearchIndexManager.php
+++ b/src/Plugin/ElasticsearchIndexManager.php
@@ -62,9 +62,33 @@ class ElasticsearchIndexManager extends DefaultPluginManager {
   }
 
   /**
+   * Clear the serialized data cache of the entity.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   */
+  public function clearEntityCache(EntityInterface $entity) {
+    foreach ($this->getDefinitions() as $plugin) {
+      if (isset($plugin['entityType']) && $entity->getEntityTypeId() == $plugin['entityType'] && (isset($plugin['cache']) && (bool) $plugin['cache'])) {
+        try {
+          $this->createInstance($plugin['id'])->clearEntityCache($entity);
+        }
+        catch (ElasticsearchException $e) {
+          $this->logger->error('Elasticsearch failed to clear entity cache: @message', [
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+    }
+  }
+
+  /**
    * Indexes the entity into any matching indices.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to index.
    *
    * @throws \Drupal\Component\Plugin\Exception\PluginException
    */


### PR DESCRIPTION
### Description

The process of re-indexing massive amount of entities are often quite slow because each entity needs to be loaded, recalculated and serialized. This process could be speed up significantly by caching the entity's serialized data when it is saved, and by loading the cached version of the entity's serialized data during re-indexing processes. The cached data is invalidated and re-created on each entity update to ensure that the cache remains up to date.

### How it works

1. Caching could be enabled per index from the index's annotation (see example).
2. Entity is serialized when it is saved.
3. The serialized data is cached (the cache ID includes language, index-id, entity-type and id as a context).
4. The serialized cached data is loaded during re-indexing

![index-cache](https://user-images.githubusercontent.com/209939/124932628-e8354780-e00b-11eb-977e-11def2829bfd.png)





