### PR TITLE
Add wildcard field type

### DIFF
--- a/src/Elasticsearch/DataType/DataTypeRepository.php
+++ b/src/Elasticsearch/DataType/DataTypeRepository.php
@@ -34,6 +34,7 @@ class DataTypeRepository implements DataTypeRepositoryInterface {
     // Text data types.
     'text' => [],
     'keyword' => [],
+    'wildcard' => [],
     // Numeric data types.
     'long' => [],
     'integer' => [],


### PR DESCRIPTION
Version 7.9 of Elasticsearch introduced a new field type called the “wildcard” field.
It is useful for instance with multi-fields text fields. One of the multifields can be analyzed text and another one wildcard field which supports wildcard queries without length limitations (which keyword field has).

https://www.elastic.co/elasticon/archive/2020/global/elasticsearch-introducing-the-wildcard-field
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/keyword.html#wildcard-field-type