### PR TITLE
Reduce memory footprint

### DIFF
--- a/config/install/elasticsearch_helper.settings.yml
+++ b/config/install/elasticsearch_helper.settings.yml
@@ -8,3 +8,4 @@ hosts:
       user: ''
       password: ''
 defer_indexing: false
+memory_safety_margin: '16M'

--- a/elasticsearch_helper.install
+++ b/elasticsearch_helper.install
@@ -139,3 +139,14 @@ function elasticsearch_helper_update_8003() {
     }
   }
 }
+
+/**
+ * Set default value for memory safety limit to 16M if it doesn't exist yet.
+ */
+function elasticsearch_helper_update_8004() {
+  $config = \Drupal::service('config.factory')->getEditable('elasticsearch_helper.settings');
+  if (is_null($config->get('memory_safety_margin'))) {
+    $config->set('memory_safety_margin', '16M');
+    $config->save();
+  }
+}


### PR DESCRIPTION
This is a PR updated for 7.x and meant for the issue originally opened at https://www.drupal.org/project/elasticsearch_helper/issues/2996457. The review comment from comment #4 has been applied (the method was moved to the queue worker).

<h3 id="summary-problem-motivation">Problem/Motivation</h3>
When trying to reindex an index with a lot of items, processing the queue may quite easily exhaust the PHP memory limit. The queue worker itself loads the entities to be indexed, which will all be added to the static cache in the entity storage, slowly eating up memory. In addition, specific index plugins may add to the problem by also loading additional entities to be folded into the index document for themselves.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>
The proposed resolution is introduce a method in the queue worker to check whether the memory is considered constrained, based on the amount of available memory, the amount of memory in use and a configurable safety margin. If we get within the safety margin, reset the entity storage for the particular entity we are processing currently.

<h3 id="summary-remaining-tasks">Remaining tasks</h3>
<ul>
  <li>Create patch</li>
  <li>Review</li>
</ul>

<h3 id="summary-ui-changes">User interface changes</h3>
None.

<h3 id="summary-api-changes">API changes</h3>
A new method on ElasticsearchIndexManager called memoryConstrained().

<h3 id="summary-data-model-changes">Data model changes</h3>
A new configuration key called memory_safety_margin using the same syntax as the PHP memory limit setting. The method checks whether current used memory plus the safety margin is still within the configured PHP memory limit.
